### PR TITLE
fix: Critical UI fixes - z-index conflict (#91) and touch targets (#92)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -47,14 +47,31 @@ a,
   cursor: pointer;
 }
 
-/* Ensure minimum touch target size (44px recommended) */
-button,
-a {
+/* Touch target utility class - opt-in only (fixes #92)
+   The previous global rule broke inline links by forcing 44px min-size.
+   Now use .touch-target class or nav-specific selectors for touch targets. */
+.touch-target,
+nav a,
+nav li a,
+nav button,
+header button,
+footer button {
   min-height: 44px;
   min-width: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Ensure inline links in content remain inline (not forced to 44px boxes) */
+p a,
+li a:not(nav li a),
+.prose a:not(.touch-target),
+.enhanced-typography a,
+article a:not(.touch-target) {
+  display: inline;
+  min-height: unset;
+  min-width: unset;
 }
 
 /* Remove hover effects on touch devices to prevent sticky states */

--- a/src/newblog/components/NewBlogPost.jsx
+++ b/src/newblog/components/NewBlogPost.jsx
@@ -627,10 +627,13 @@ const NewBlogPost = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50">
-      {/* Reading Progress Bar */}
+      {/* Reading Progress Bar - positioned below header using CSS variable */}
       {isClient && (
-        <div className="fixed top-0 left-0 w-full h-1 bg-gray-200 z-50">
-          <div 
+        <div
+          className="fixed left-0 w-full h-1 bg-gray-200 z-sticky"
+          style={{ top: 'var(--header-height, 80px)' }}
+        >
+          <div
             className="h-full bg-gradient-to-r from-green-500 to-green-600 transition-all duration-150 ease-out"
             style={{ width: `${readingProgress}%` }}
           />


### PR DESCRIPTION
## Summary
Fixes two critical P0 UI issues identified by automated Grok + Gemini audit:

### Issue #91: Z-Index Conflict
- **Problem**: Reading progress bar (z-50) rendered ON TOP of header (z-30)
- **Fix**: Changed to z-sticky (20) with `top: var(--header-height, 80px)`
- **Result**: Progress bar now renders below header, visible during scroll

### Issue #92: Touch Targets Breaking Layouts
- **Problem**: Global 44px min-size on ALL `<a>` and `<button>` elements broke inline links
- **Fix**: 
  - Removed global rule
  - Added opt-in `.touch-target` class
  - Scoped to `nav a`, `header button`, `footer button`
  - Added reset for content links (`p a`, `.prose a`, etc.)
- **Specificity fix**: Added `nav li a` to beat `li a` reset (caught by Gemini)

## Files Changed
- `src/index.css` - Touch target CSS restructured
- `src/newblog/components/NewBlogPost.jsx` - Progress bar z-index and positioning

## Review Process
| Step | Tool | Result |
|------|------|--------|
| Audit | Grok + Gemini | Both flagged these issues |
| PRD Review | Grok + Gemini | Both provided feedback |
| Code Review | Grok | ✅ Approved |
| Code Review | Gemini | ⚠️ Found specificity bug → Fixed |

## Test Plan
- [x] Build succeeds
- [ ] Verify progress bar visible below header on blog posts
- [ ] Verify header navigation clickable
- [ ] Verify inline links in blog content flow naturally
- [ ] Verify nav links maintain 44px touch targets
- [ ] Test on mobile viewport

Closes #91, Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)