### PR TITLE
fix: P1 layout shift fixes (#93, #94, #95)

### DIFF
--- a/src/components/LazyImage.jsx
+++ b/src/components/LazyImage.jsx
@@ -1,13 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-const LazyImage = ({ 
-  src, 
-  alt, 
+const LazyImage = ({
+  src,
+  alt,
   className = '',
+  aspectRatio = '16/9', // Default aspect ratio to prevent CLS
   threshold = 0.1,
   rootMargin = '50px',
   placeholder = 'blur',
-  ...props 
+  ...props
 }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isInView, setIsInView] = useState(false);
@@ -55,12 +56,12 @@ const LazyImage = ({
   const showBackground = !isLoaded && !hasError;
 
   return (
-    <div 
+    <div
       ref={imgRef}
-      className="relative w-full h-full"
-      style={{ 
+      className="relative w-full"
+      style={{
         backgroundColor: showBackground ? '#f3f4f6' : 'transparent',
-        minHeight: '200px' // Ensure the container has height for intersection observer
+        aspectRatio: aspectRatio, // Use aspect-ratio instead of minHeight to prevent CLS
       }}
     >
       {/* Debug info (remove in production) */}
@@ -74,11 +75,9 @@ const LazyImage = ({
         <img
           src={src}
           alt={alt}
-          className={`${className} transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
+          className={`${className} w-full h-full object-cover transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
           onLoad={handleLoad}
           onError={handleError}
-          // Remove native lazy loading to avoid conflicts
-          // loading="lazy"
           {...props}
         />
       )}

--- a/src/newblog/components/NewBlogPost.jsx
+++ b/src/newblog/components/NewBlogPost.jsx
@@ -742,7 +742,7 @@ const NewBlogPost = () => {
         {/* Table of Contents - Desktop Sidebar */}
         {isClient && tocItems.length > 0 && (
           <div className="hidden lg:block w-64 flex-shrink-0">
-            <div className="sticky top-24">
+            <div className="sticky" style={{ top: 'calc(var(--header-height, 80px) + 16px)' }}>
               <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-100">
                 <h3 className="font-bold text-gray-900 mb-4 flex items-center gap-2">
                   <List className="w-4 h-4 text-green-600" />
@@ -822,13 +822,13 @@ const NewBlogPost = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="bg-white rounded-xl shadow-lg overflow-hidden">
-            {/* Hero Image */}
+            {/* Hero Image - uses aspect-video for consistent ratio and no CLS */}
             {post.image && (
               <div className="w-full">
-                <img 
-                  src={post.image} 
+                <img
+                  src={post.image}
                   alt={`${post.title} - DHM Guide`}
-                  className="w-full h-64 md:h-80 lg:h-96 object-cover"
+                  className="w-full aspect-video object-cover"
                   loading="eager"
                 />
               </div>


### PR DESCRIPTION
## Summary
- **#93 LazyImage CLS**: Added `aspectRatio` prop (default '16/9') replacing `minHeight: 200px` to prevent cumulative layout shift
- **#94 Blog Hero Images**: Changed from fixed heights (`h-64 md:h-80 lg:h-96`) to `aspect-video` for consistent aspect ratio
- **#95 Sticky TOC**: Uses `calc(var(--header-height, 80px) + 16px)` instead of hardcoded `top-24` for dynamic header support

## Code Review
Both Grok and Gemini approved:
- **Grok**: "APPROVAL WITH FIXES" - all implementations correct, suggested optional optimization
- **Gemini**: "APPROVED with minor considerations" - all changes technically correct

## Test plan
- [ ] Verify LazyImage reserves correct space before image loads (no CLS)
- [ ] Verify blog hero images maintain 16:9 aspect ratio across viewport sizes
- [ ] Verify TOC stays properly positioned below header on scroll
- [ ] Test on mobile and desktop viewports

Closes #93, closes #94, closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)