### PR TITLE
Fix: Add redirect for /never-hangover/ typo path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,11 @@
       "permanent": true
     },
     {
+      "source": "/never-hangover/:path*",
+      "destination": "/never-hungover/:path*",
+      "permanent": true
+    },
+    {
       "source": "/never-hungover/quantum-health-monitoring-alcohol-guide-2025",
       "destination": "/never-hungover",
       "permanent": true


### PR DESCRIPTION
## Summary
- Added 301 redirect in `vercel.json`: `/never-hangover/:path*` → `/never-hungover/:path*`
- No internal code typo found — the 4 PostHog pageviews came from external/mistyped links

Closes #260

## Test Plan
- [x] `npm run build` passes
- [ ] Verify redirect works on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)