### PR TITLE
Feat: Experiment to make /reviews product cards and badges clickable

### DIFF
--- a/.specs/258-clickable-cards/design.md
+++ b/.specs/258-clickable-cards/design.md
@@ -1,0 +1,71 @@
+# Design: Make /reviews product cards and badges clickable (#258)
+
+## Approach
+Minimal changes: wrap two currently non-clickable elements in `<a>` tags behind a feature flag.
+
+## Change 1: Badge becomes clickable
+
+**Current (line 767-769):**
+```jsx
+<Badge className={getBadgeColor(product.badgeColor)}>
+  {product.badge}
+</Badge>
+```
+
+**Test variant:**
+```jsx
+<a
+  href={product.affiliateLink}
+  target="_blank"
+  rel="nofollow sponsored noopener noreferrer"
+  data-placement="product_card_badge"
+  data-product-name={product.name}
+  aria-label={`${product.badge} - ${product.name} on Amazon`}
+  className="inline-flex"
+>
+  <Badge className={`${getBadgeColor(product.badgeColor)} hover:opacity-80 transition-opacity cursor-pointer`}>
+    {product.badge}
+  </Badge>
+</a>
+```
+
+## Change 2: Trust signals near CTA become clickable
+
+**Current (lines 931-940):**
+```jsx
+<div className="flex items-center justify-center gap-2 text-xs text-gray-500 mt-2">
+  <Star ... />
+  <span>{product.rating} (...)</span>
+  ...
+</div>
+```
+
+**Test variant:**
+```jsx
+<a
+  href={product.affiliateLink}
+  target="_blank"
+  rel="nofollow sponsored noopener noreferrer"
+  data-placement="product_card_trust"
+  data-product-name={product.name}
+  className="flex items-center justify-center gap-2 text-xs text-gray-500 mt-2 hover:text-green-700 transition-colors"
+>
+  <Star ... />
+  <span>{product.rating} (...)</span>
+  ...
+</a>
+```
+
+## Feature Flag Integration
+```jsx
+const clickableCardsVariant = useFeatureFlag('reviews-clickable-cards-v1', 'control')
+const isClickableCards = clickableCardsVariant === 'test'
+```
+
+Conditional rendering uses `isClickableCards` ternary for each element.
+
+## What we are NOT doing
+- NOT making the entire card clickable (would create nested link issues with existing links)
+- NOT adding click handlers or custom tracking code (useAffiliateTracking auto-detects)
+- NOT changing the comparison table (already mostly linked)
+- NOT changing the CTA button (already works)

--- a/.specs/258-clickable-cards/requirements.md
+++ b/.specs/258-clickable-cards/requirements.md
@@ -1,0 +1,42 @@
+# Requirements: Make /reviews product cards and badges clickable (#258)
+
+## Feature Flag
+- Key: `reviews-clickable-cards-v1`
+- Type: multivariate (control / test)
+- Control: current /reviews (badges are plain text, card areas not linked)
+- Test: badges and additional card areas become clickable affiliate links
+
+## Goal Metrics
+- Primary: increase `affiliate_link_click` events on /reviews
+- Secondary: reduce dead clicks (rage_click_detected / element_clicked with no target)
+
+## Requirements
+
+### R1: Badge becomes clickable (test variant)
+- The product badge (e.g., "Editor's Choice", "Best Value") wraps in an `<a>` tag
+- Links to the same `product.affiliateLink`
+- Uses `data-placement="product_card_badge"` for tracking
+- Uses `data-product-name={product.name}` for product identification
+
+### R2: Trust signals near CTA become clickable (test variant)
+- The rating/review count trust signal text below CTA wraps in an `<a>` tag
+- Links to `product.affiliateLink`
+- Uses `data-placement="product_card_trust"` for tracking
+
+### R3: Maintain existing CTA button
+- The "Check Price on Amazon" button remains unchanged
+- All existing clickable elements remain as-is
+
+### R4: Proper affiliate link attributes
+- All new `<a>` tags use: `target="_blank" rel="nofollow sponsored noopener noreferrer"`
+- All new links include `data-product-name={product.name}`
+
+### R5: Accessibility
+- New links have clear visual affordances (hover underline/color change)
+- No nested interactive elements (no `<a>` inside `<a>` or `<button>` inside `<a>`)
+- Badge links get `aria-label` for screen readers
+
+### R6: Tracking fires correctly
+- Existing `useAffiliateTracking` hook auto-detects clicks on `<a>` tags with Amazon URLs
+- New links include `data-placement` so detectPlacement() returns the correct value
+- No additional tracking code needed beyond data attributes

--- a/.specs/258-clickable-cards/research.md
+++ b/.specs/258-clickable-cards/research.md
@@ -1,0 +1,57 @@
+# Research: Make /reviews product cards and badges clickable (#258)
+
+## Problem
+/reviews has 90 dead clicks (48.9 per 100 views) -- worst on the site. Users tap product names and trust badges expecting them to be links.
+
+## Current State (Reviews.jsx)
+
+### Product Card Structure (lines 750-944)
+Each product card is a `<Card>` component rendered inside a `<motion.div>`.
+
+**Already clickable (wrapped in `<a>` tags):**
+- Product name / CardTitle (line 771-779) -- links to `product.affiliateLink`
+- Price (line 801-809) -- links to `product.affiliateLink`
+- Rating/stars (line 783-793) -- links to `product.affiliateLink`
+- "Best For" section (line 879-888) -- links to `product.affiliateLink`
+- Main CTA button (line 893-905) -- "Check Price on Amazon"
+
+**NOT clickable (dead click targets):**
+- Badge (line 767-769): `<Badge>` with text like "Editor's Choice", "Best Value" -- plain component, no link
+- Card background/container (line 761): `<Card>` with hover shadow but no link
+- "Free Shipping" pill (line 900-902): Inside the CTA `<a>` so technically clickable, but its visual badge style makes users tap it independently
+- Trust signals near CTA (lines 931-940): Rating repeat + monthly buyers -- not linked
+- "per serving" text (line 810): Not linked
+- "servings" text (line 811): Not linked
+
+### Comparison Table (lines 623-744)
+Most cells ARE already linked. Brand name (line 662-671), price, per-serving, rating, score, and action button all link to affiliate URLs. Reviews count (line 708) is NOT linked.
+
+### Affiliate URL Source
+Each product object has an `affiliateLink` property (e.g., "https://amzn.to/3HSHjgu"). All links use the same URL per product.
+
+### Feature Flag Pattern
+- `useFeatureFlag` hook from `src/hooks/useFeatureFlag.js`
+- Returns flag value (boolean for simple, string for multivariate)
+- Example usage: `const stickyBarVariant = useFeatureFlag('sticky-recommendation-bar-v1', 'control')`
+- Conditional rendering: `{stickyBarVariant === 'sticky-bar' && ...}`
+
+### Tracking
+- `data-product-name` attribute used on links for affiliate tracking
+- `detectPlacement()` in useAffiliateTracking.js uses DOM classes (`.product-card`, `.review-card`)
+- `data-placement` attribute checked as override in detectPlacement (line 44)
+- `trackElementClick` from posthog used for specific CTA tracking
+
+### Dead Click Analysis (from issue)
+- "No Days Wasted DHM Detox" (15 dead clicks) -- product name text (BUT name IS already linked -- likely clicking near it but missing the link, or tapping the badge next to it)
+- "Double Wood Supplements DHM" (13) -- same pattern
+- "Check Price on Amazon" (11) -- possibly small touch target or clicking badge area
+- "Free Shipping" badge (7) -- visual badge style invites clicks
+
+## Key Insight
+Product names ARE already clickable links. The dead clicks are likely on:
+1. The badge next to the product name (e.g., "Editor's Choice")
+2. The card area around the product name (not the link itself)
+3. The "Free Shipping" badge visual element
+4. Trust signal text near the CTA
+
+The fix should focus on: making badges clickable and potentially making the entire card header area a larger click target.

--- a/.specs/258-clickable-cards/tasks.md
+++ b/.specs/258-clickable-cards/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Make /reviews product cards and badges clickable (#258)
+
+## Task 1: Add feature flag
+- Add `useFeatureFlag('reviews-clickable-cards-v1', 'control')` to Reviews component
+- Derive `isClickableCards` boolean
+
+## Task 2: Make badge clickable in test variant
+- Wrap Badge in `<a>` tag when `isClickableCards` is true
+- Add data-placement="product_card_badge" and data-product-name
+- Add aria-label for accessibility
+- Add hover:opacity-80 visual feedback
+
+## Task 3: Make trust signals clickable in test variant
+- Change trust signal `<div>` to `<a>` tag when `isClickableCards` is true
+- Add data-placement="product_card_trust" and data-product-name
+- Add hover:text-green-700 visual feedback
+
+## Task 4: Build verification
+- Run `npm run build` to verify no errors
+
+## Task 5: Commit
+- Commit with message referencing #258

--- a/src/pages/Reviews.jsx
+++ b/src/pages/Reviews.jsx
@@ -50,6 +50,10 @@ export default function Reviews() {
   // A/B Test #255: Scarcity badges - time urgency on product cards
   const scarcityVariant = useFeatureFlag('scarcity-badges-v1', 'control')
 
+  // A/B Test #258: Make product card badges and trust signals clickable
+  const clickableCardsVariant = useFeatureFlag('reviews-clickable-cards-v1', 'control')
+  const isClickableCards = clickableCardsVariant === 'test'
+
   // A/B Test #139: Sticky Recommendation Bar - KEEPING this test
   const stickyBarVariant = useFeatureFlag('sticky-recommendation-bar-v1', 'control')
   const [showStickyBar, setShowStickyBar] = useState(false)
@@ -777,9 +781,25 @@ export default function Reviews() {
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
                           <span className="text-2xl font-bold text-gray-400">#{index + 1}</span>
-                          <Badge className={getBadgeColor(product.badgeColor)}>
-                            {product.badge}
-                          </Badge>
+                          {isClickableCards ? (
+                            <a
+                              href={product.affiliateLink}
+                              target="_blank"
+                              rel="nofollow sponsored noopener noreferrer"
+                              data-placement="product_card_badge"
+                              data-product-name={product.name}
+                              aria-label={`${product.badge} - ${product.name} on Amazon`}
+                              className="inline-flex"
+                            >
+                              <Badge className={`${getBadgeColor(product.badgeColor)} hover:opacity-80 transition-opacity cursor-pointer`}>
+                                {product.badge}
+                              </Badge>
+                            </a>
+                          ) : (
+                            <Badge className={getBadgeColor(product.badgeColor)}>
+                              {product.badge}
+                            </Badge>
+                          )}
                           {/* A/B Test #255: scarcity-badges-v1 time-urgency variant */}
                           {scarcityVariant === 'time-urgency' && product.reviews > 100 && (
                             <span className="text-xs text-orange-600 font-medium">
@@ -951,16 +971,36 @@ export default function Reviews() {
                       </Button>
                     </div>
                     {/* Trust Signals Near CTA */}
-                    <div className="flex items-center justify-center gap-2 text-xs text-gray-500 mt-2">
-                      <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" aria-hidden="true" />
-                      <span>{product.rating} ({product.reviews?.toLocaleString() || 'N/A'} reviews)</span>
-                      {product.monthlyBuyers && (
-                        <>
-                          <span aria-hidden="true">•</span>
-                          <span>{product.monthlyBuyers} monthly buyers</span>
-                        </>
-                      )}
-                    </div>
+                    {isClickableCards ? (
+                      <a
+                        href={product.affiliateLink}
+                        target="_blank"
+                        rel="nofollow sponsored noopener noreferrer"
+                        data-placement="product_card_trust"
+                        data-product-name={product.name}
+                        className="flex items-center justify-center gap-2 text-xs text-gray-500 mt-2 hover:text-green-700 transition-colors"
+                      >
+                        <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" aria-hidden="true" />
+                        <span>{product.rating} ({product.reviews?.toLocaleString() || 'N/A'} reviews)</span>
+                        {product.monthlyBuyers && (
+                          <>
+                            <span aria-hidden="true">•</span>
+                            <span>{product.monthlyBuyers} monthly buyers</span>
+                          </>
+                        )}
+                      </a>
+                    ) : (
+                      <div className="flex items-center justify-center gap-2 text-xs text-gray-500 mt-2">
+                        <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" aria-hidden="true" />
+                        <span>{product.rating} ({product.reviews?.toLocaleString() || 'N/A'} reviews)</span>
+                        {product.monthlyBuyers && (
+                          <>
+                            <span aria-hidden="true">•</span>
+                            <span>{product.monthlyBuyers} monthly buyers</span>
+                          </>
+                        )}
+                      </div>
+                    )}
                     <p className="text-xs text-gray-600 mt-1 text-center">
                       As an Amazon Associate I earn from qualifying purchases
                     </p>


### PR DESCRIPTION
## Summary
- Feature flag `reviews-clickable-cards-v1` controls the experiment
- Test variant: product badges ("Editor's Choice", "Best Value") and trust signals become clickable affiliate links
- Added `data-placement` attributes: `product_card_badge`, `product_card_trust`
- Existing "Check Price" buttons unchanged

Closes #258

## Context
/reviews has 90 dead clicks / 90 days (48.9 per 100 views). Users tap product badges and trust text expecting them to be links.

## Changes
- `src/pages/Reviews.jsx` — badge becomes `<a>` in test variant (line 771-787), trust signals become `<a>` (line 951-974)
- Accessibility: proper `aria-label` on new clickable elements

## Test Plan
- [x] `npm run build` passes
- [ ] Create flag `reviews-clickable-cards-v1` in PostHog (control/test, 50/50)
- [ ] Monitor dead_click reduction and affiliate_link_click lift on /reviews
- [ ] Target: ≥200 incremental clicks before declaring winner

🤖 Generated with [Claude Code](https://claude.com/claude-code)