### PR TITLE
fix: unify product-name attribution and mobile-menu event name

### DIFF
--- a/src/components/ComparisonWidget.jsx
+++ b/src/components/ComparisonWidget.jsx
@@ -178,7 +178,7 @@ export default function ComparisonWidget({
                           target="_blank"
                           rel="nofollow sponsored noopener noreferrer"
                           data-placement="comparison_widget"
-                          data-product-name={selectedProducts[0].brand}
+                          data-product-name={selectedProducts[0].name}
                           className="flex items-center justify-center"
                         >
                           <ShoppingCart className="w-4 h-4 mr-2" />

--- a/src/components/MobileComparisonWidget.jsx
+++ b/src/components/MobileComparisonWidget.jsx
@@ -181,7 +181,7 @@ export default function MobileComparisonWidget({
                       target="_blank"
                       rel="nofollow sponsored noopener noreferrer"
                       data-placement="comparison_widget"
-                      data-product-name={selectedProducts[0].brand}
+                      data-product-name={selectedProducts[0].name}
                       className="flex items-center justify-center"
                     >
                       <ShoppingCart className="w-4 h-4 mr-2" />

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -129,7 +129,7 @@ function Layout({ children }) {
               className="lg:hidden p-3 text-gray-600 hover:text-green-600 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center flex-shrink-0"
               aria-label={isMenuOpen ? "Close menu" : "Open menu"}
               aria-expanded={isMenuOpen}
-              data-track="mobile-menu"
+              data-track="mobile_menu"
             >
               {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>

--- a/src/hooks/useElementTracking.js
+++ b/src/hooks/useElementTracking.js
@@ -16,7 +16,7 @@ const ELEMENT_SELECTORS = {
   nav: '[data-track="nav"], nav a, .nav-link',
   faq: '[data-track="faq"]',
   share: '[data-track="share"]',
-  mobile_menu: '[data-track="mobile-menu"]'
+  mobile_menu: '[data-track="mobile_menu"]'
 };
 
 /**


### PR DESCRIPTION
(1) ComparisonWidget/MobileComparisonWidget were emitting `data-product-name={brand}` instead of `{name}`, splitting product attribution. (2) `mobile-menu` and `mobile_menu` were both firing as separate events (60d: 37 vs 13). Standardized on snake_case across `Layout.jsx` and `useElementTracking.js`.

Refs #268.