### PR TITLE
feat: front-load comparison table above-fold on mobile (/reviews, /compare)

### DIFF
--- a/src/pages/Compare.jsx
+++ b/src/pages/Compare.jsx
@@ -434,7 +434,7 @@ export default function Compare() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-blue-50 flex flex-col">
       {/* Hero Section */}
       <section className="pt-8 pb-16 px-4">
         <div className="container mx-auto">
@@ -529,9 +529,9 @@ export default function Compare() {
         </div>
       </section>
 
-      {/* Comparison Table Section */}
+      {/* Comparison Table Section - order-first on mobile to front-load above hero (Issue: mobile CR 2.9x desktop, but lower scroll depth) */}
       {selectedProductsData.length > 0 && (
-        <section className="py-8 px-4">
+        <section className="order-first md:order-none py-8 px-4 min-h-[600px] md:min-h-0">
           <div className="container mx-auto max-w-7xl">
             <motion.div
               initial={{ opacity: 0, y: 30 }}

--- a/src/pages/Reviews.jsx
+++ b/src/pages/Reviews.jsx
@@ -448,7 +448,7 @@ export default function Reviews() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-blue-50 flex flex-col">
       {/* Hero Section */}
       <section className="pt-6 pb-8 md:pb-12 px-4">
         <div className="container mx-auto">
@@ -631,8 +631,11 @@ export default function Reviews() {
         </div>
       </section>
 
-      {/* Quick Comparison Table */}
-      <section className="py-8 px-4 bg-gray-50">
+      {/* Quick Comparison Table - order-first on mobile to front-load above hero (Issue: mobile CR 2.9x desktop, but lower scroll depth) */}
+      <section
+        id="comparison-table"
+        className="order-first md:order-none py-8 px-4 bg-gray-50 min-h-[520px] md:min-h-0"
+      >
         <div className="container mx-auto max-w-6xl">
           <motion.div
             initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
Mobile CR is **2.9× desktop** but mobile users scroll less deep (only 17% reach 90%). `order-first md:order-none` on the comparison-table section: mobile shows it first, desktop unchanged. CLS reserved with `min-h-[520px/600px]`. Verified via Playwright on iPhone 14 + desktop.

Refs #268.