### PR TITLE
chore: hygiene + UTM standard + dead-click filter (env-var-only API key)

### DIFF
--- a/docs/posthog-analysis-2026-04-25/r10-hygiene.md
+++ b/docs/posthog-analysis-2026-04-25/r10-hygiene.md
@@ -1,0 +1,141 @@
+# R10 - Hygiene + UTM Status
+
+**Date:** 2026-04-26
+**Branch:** `chore/hygiene-and-utm` (items 1-3) + amend on `fix/affiliate-button-audit` (item 4)
+**Commit:** `d698343` (chore branch) / `cdb436c` (amended affiliate-button-audit)
+
+## Summary
+
+| # | Task | Status | Proof |
+|---|------|--------|-------|
+| 1 | Rotate dead PostHog API key | DONE | `./scripts/posthog-query.sh events` returns real counts (780 pageviews, 482 web_vitals, ...) |
+| 2 | Dead-click filter queries | DONE | raw=46, real=35 -> filter removes 11 affiliate false-positives |
+| 3 | UTM tagging recommendation | DONE | `scripts/utm-tag.sh` + `docs/posthog-analysis-2026-04-25/r10-utm-standard.md` |
+| 4 | Recommit `fix/affiliate-button-audit` | DONE | tree unchanged (`d40e0b8...`), new hash `cdb436c`, correct message |
+
+## Item 1: API key handling — env-var only
+
+**File:** `scripts/posthog-query.sh:5`
+
+Removed the hardcoded fallback (originally a revoked key, briefly rotated to a live key — both are inappropriate to commit). The script now requires `POSTHOG_PERSONAL_API_KEY` from the environment and fails fast with a clear error if unset:
+
+```bash
+API_KEY="${POSTHOG_PERSONAL_API_KEY:?Set POSTHOG_PERSONAL_API_KEY in your environment (~/.zshrc) — see docs/posthog-analysis-2026-04-25/r10-hygiene.md}"
+```
+
+This eliminates the secret-scanning push-blocker and matches the project's stated convention (CLAUDE.md says the key lives in `~/.zshrc`).
+
+**Verified:** with `POSTHOG_PERSONAL_API_KEY` exported, `./scripts/posthog-query.sh events` returns:
+
+```
+$pageview: 780
+$web_vitals: 482
+$feature_flag_called: 393
+scroll_depth_milestone: 230
+$pageleave: 153
+time_on_page_milestone: 82
+element_clicked: 73
+funnel_step: 51
+$dead_click: 46
+...
+```
+
+**Required ~/.zshrc addition** (user-side action, NOT applied — secret intentionally redacted from this doc):
+
+```bash
+# Add to ~/.zshrc — get the key value from PostHog dashboard:
+# https://us.posthog.com/settings/user-api-keys
+export POSTHOG_PERSONAL_API_KEY="phx_..."
+```
+
+After adding, `source ~/.zshrc`. The script fails fast with a helpful error if this isn't set. Per project CLAUDE.md the key is supposed to live in zshrc.
+
+## Item 2: Dead-click filter (don't merge fix/affiliate-dead-clicks)
+
+**Recommendation: do NOT merge `fix/affiliate-dead-clicks` (commit `bd2461f`).**
+
+That branch globally disables `capture_dead_clicks`, killing real UX signal across the entire site (e.g. on `/nac-vs-dhm` and other content pages where dead clicks ARE actionable). The PostHog auto-heuristic only false-fires on `target="_blank"` external links because the source tab does not change.
+
+The right fix is filter-at-query-time, baked into the helper script as two new subcommands:
+
+```bash
+./scripts/posthog-query.sh dead-clicks-raw   # 46 events (incl. affiliate noise)
+./scripts/posthog-query.sh dead-clicks-real  # 35 events (actionable signal)
+```
+
+Difference: 11 dead-click events were Amazon/Fuller affiliate false-positives — confirms the X2 forensics finding.
+
+**Canonical filter (in `scripts/posthog-query.sh:dead-clicks-real`):**
+
+```sql
+SELECT count() AS c
+FROM events
+WHERE event = '$dead_click'
+  AND coalesce(properties.$external_click_url, '') NOT LIKE '%amzn%'
+  AND coalesce(properties.$external_click_url, '') NOT LIKE '%amazon%'
+  AND coalesce(properties.$external_click_url, '') NOT LIKE '%fullerhealth%'
+  AND timestamp > now() - INTERVAL 7 DAY
+```
+
+Use this filter as a saved insight in PostHog and as the "real dead clicks" tile on any UX-health dashboard.
+
+## Item 3: UTM standard
+
+Convention + helper + HogQL queries shipped:
+
+- `scripts/utm-tag.sh` — outputs tagged URL given URL + channel + optional campaign
+- `docs/posthog-analysis-2026-04-25/r10-utm-standard.md` — full convention, examples, and HogQL queries to save in PostHog
+
+**Verified examples (live output):**
+
+```
+$ ./scripts/utm-tag.sh https://www.dhmguide.com/reviews newsletter
+https://www.dhmguide.com/reviews?utm_source=newsletter&utm_medium=email&utm_campaign=2026-04
+
+$ ./scripts/utm-tag.sh https://www.dhmguide.com/never-hungover x launch-2026-q2
+https://www.dhmguide.com/never-hungover?utm_source=x&utm_medium=social&utm_campaign=launch-2026-q2
+
+$ ./scripts/utm-tag.sh "https://www.dhmguide.com/page?ref=foo" reddit
+https://www.dhmguide.com/page?ref=foo&utm_source=reddit&utm_medium=social&utm_campaign=2026-04
+```
+
+Scope: forward-only. We are NOT retro-tagging existing links — see `r10-utm-standard.md` for rationale.
+
+## Item 4: Amended commit on `fix/affiliate-button-audit`
+
+**Before:** `585e2f1df47d1c8e911116b61d52fdcc21f46273`
+- Subject: `test: add P0 affiliate-click regression suite` (P0-D's message — wrong)
+
+**After:** `cdb436c56862c79c5d6835bffb5fd48dfb5534c4`
+- Subject: `fix: tag inline blog Amazon links and audit affiliate buttons site-wide`
+
+**Tree hash unchanged** (`d40e0b8df49a89114d1e6d23552d66ed93d88312` before and after) — content is identical, only the commit message changed. Diff stat verified identical:
+
+```
+docs/posthog-analysis-2026-04-25/p0e-button-audit.md  | 162 +++++++++++++++++
+src/newblog/components/NewBlogPost.jsx                |  16 +-
+2 files changed, 172 insertions(+), 6 deletions(-)
+```
+
+Branch `fix/affiliate-button-audit` was unmerged and unpushed when amended; per task brief this is appropriate scope for `--amend`. **A `git push --force-with-lease origin fix/affiliate-button-audit` will be needed when the user is ready to push** (not done — awaiting approval).
+
+## Verification log
+
+```
+$ npm run build           -> PASS (prerender of /, /guide, /reviews, /research, /about, /dhm-dosage-calculator, /compare)
+$ ./scripts/posthog-query.sh events            -> 780 pageviews, 16 affiliate clicks, 46 dead-clicks, etc.
+$ ./scripts/posthog-query.sh dead-clicks-raw   -> count: 46
+$ ./scripts/posthog-query.sh dead-clicks-real  -> count: 35
+$ git log -1 fix/affiliate-button-audit        -> cdb436c "fix: tag inline blog Amazon links..."
+```
+
+## Files touched on this branch
+
+```
+scripts/posthog-query.sh                              | modified (+34, -7)
+scripts/utm-tag.sh                                    | new (executable)
+docs/posthog-analysis-2026-04-25/r10-utm-standard.md  | new
+docs/posthog-analysis-2026-04-25/r10-hygiene.md       | this file
+```
+
+No production code (hooks, components, blog posts, tests) touched per scope. Build passes.

--- a/docs/posthog-analysis-2026-04-25/r10-utm-standard.md
+++ b/docs/posthog-analysis-2026-04-25/r10-utm-standard.md
@@ -1,0 +1,129 @@
+# R10 - UTM Tagging Standard for Owned Channels
+
+**Date:** 2026-04-26
+**Owner:** analytics hygiene
+**Status:** Recommended convention (not yet enforced on existing links)
+
+## Why this matters
+
+PostHog traffic-source data shows the site receives ~60% Google-organic traffic, with the remaining 40% spread across direct, referral, and "other". There is **no meaningful UTM-tagged owned-channel traffic** - meaning we cannot answer simple questions like:
+
+- How many newsletter subscribers actually read the latest comparison post?
+- Which X/Twitter post drove the most affiliate clicks?
+- Did our Reddit thread convert at all?
+- Is LinkedIn worth posting to?
+
+Without UTMs, all of this collapses into "direct" or "referrer = unknown" in PostHog.
+
+## Convention
+
+Every link we publish on a channel we own (newsletter, social, podcast description, etc.) MUST carry these three params:
+
+```
+?utm_source=<channel>&utm_medium=<medium>&utm_campaign=<campaign>
+```
+
+### Standard `utm_source` / `utm_medium` pairs
+
+| Channel       | utm_source   | utm_medium |
+| ------------- | ------------ | ---------- |
+| Newsletter    | `newsletter` | `email`    |
+| X / Twitter   | `x`          | `social`   |
+| LinkedIn      | `linkedin`   | `social`   |
+| Reddit        | `reddit`     | `social`   |
+| Facebook      | `facebook`   | `social`   |
+| YouTube       | `youtube`    | `video`    |
+| Podcast notes | `podcast`    | `audio`    |
+
+Use lowercase. No spaces. Use `x` (not `twitter`) going forward, but the helper accepts both.
+
+### `utm_campaign`
+
+Default to `YYYY-MM` (current month, e.g. `2026-04`). Override only when running a named launch:
+
+- `launch-2026-q2` - quarterly product launch
+- `dhm-vs-nac-deep-dive` - specific content campaign
+- `black-friday-2026` - seasonal
+
+Don't put PII or full post slugs in the campaign field - that's what the path is for.
+
+## Concrete examples
+
+| Channel    | Tagged URL                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| Newsletter | `https://www.dhmguide.com/reviews?utm_source=newsletter&utm_medium=email&utm_campaign=2026-04`                   |
+| X          | `https://www.dhmguide.com/never-hungover?utm_source=x&utm_medium=social&utm_campaign=2026-04`                    |
+| LinkedIn   | `https://www.dhmguide.com/dhm-research?utm_source=linkedin&utm_medium=social&utm_campaign=2026-04`               |
+| Reddit     | `https://www.dhmguide.com/nac-vs-dhm?utm_source=reddit&utm_medium=social&utm_campaign=dhm-vs-nac-deep-dive`      |
+
+## Helper script
+
+`scripts/utm-tag.sh` builds tagged URLs for you. Don't hand-craft these - typos break attribution silently.
+
+```bash
+./scripts/utm-tag.sh https://www.dhmguide.com/reviews newsletter
+# -> https://www.dhmguide.com/reviews?utm_source=newsletter&utm_medium=email&utm_campaign=2026-04
+
+./scripts/utm-tag.sh https://www.dhmguide.com/never-hungover x launch-2026-q2
+# -> https://www.dhmguide.com/never-hungover?utm_source=x&utm_medium=social&utm_campaign=launch-2026-q2
+
+./scripts/utm-tag.sh "https://www.dhmguide.com/page?ref=foo" reddit
+# -> https://www.dhmguide.com/page?ref=foo&utm_source=reddit&utm_medium=social&utm_campaign=2026-04
+```
+
+The helper handles the `?` vs `&` separator automatically and defaults the campaign to the current month.
+
+## HogQL queries to save in PostHog
+
+Save these in PostHog -> SQL editor -> Save as. Owned-channel performance becomes a 1-click view.
+
+### 1) Owned-channel traffic, last 30d
+
+```sql
+SELECT
+  properties.utm_source AS source,
+  properties.utm_medium AS medium,
+  count() AS sessions
+FROM events
+WHERE event = '$pageview'
+  AND properties.utm_source IS NOT NULL
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY source, medium
+ORDER BY sessions DESC
+```
+
+### 2) Owned-channel affiliate conversions, last 30d
+
+```sql
+SELECT
+  properties.utm_source AS source,
+  properties.utm_campaign AS campaign,
+  count() AS affiliate_clicks
+FROM events
+WHERE event = 'affiliate_link_click'
+  AND properties.utm_source IS NOT NULL
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY source, campaign
+ORDER BY affiliate_clicks DESC
+```
+
+### 3) Per-campaign funnel (pageview -> scroll 50 -> affiliate click)
+
+```sql
+SELECT
+  properties.utm_campaign AS campaign,
+  countIf(event = '$pageview') AS pageviews,
+  countIf(event = 'scroll_depth_milestone' AND properties.depth_percentage >= 50) AS scrolled_50,
+  countIf(event = 'affiliate_link_click') AS clicked_amazon
+FROM events
+WHERE properties.utm_campaign IS NOT NULL
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY campaign
+ORDER BY pageviews DESC
+```
+
+## Scope: forward-only
+
+We are **not** retro-tagging existing links. The cost (auditing newsletter archives, social post histories, etc.) outweighs the benefit (historical data is already noisy, and PostHog only retains 7-90d of detail anyway depending on plan).
+
+**Going forward** - every new owned-channel post gets a tagged URL via `scripts/utm-tag.sh`. After ~30 days of consistent tagging, the HogQL queries above will give us real owned-channel ROI numbers.

--- a/scripts/posthog-query.sh
+++ b/scripts/posthog-query.sh
@@ -2,7 +2,7 @@
 # PostHog Query Helper for DHM Guide
 # Usage: ./scripts/posthog-query.sh [command]
 
-API_KEY="${POSTHOG_PERSONAL_API_KEY:-phx_V9NkxY2istxJLQ0HZEin1qB57DwULWhUShGSHGMz8oFM92c}"
+API_KEY="${POSTHOG_PERSONAL_API_KEY:?Set POSTHOG_PERSONAL_API_KEY in your environment (~/.zshrc) — see docs/posthog-analysis-2026-04-25/r10-hygiene.md}"
 BASE_URL="https://us.posthog.com/api/projects/@current"
 
 case "$1" in
@@ -51,8 +51,26 @@ for e in d.get('results',[]):
     ;;
 
   funnel)
-    echo "=== Conversion Funnel (Pageview → Scroll 50% → Affiliate Click) ==="
+    echo "=== Conversion Funnel (Pageview -> Scroll 50% -> Affiliate Click) ==="
     echo "Coming soon - requires funnel query setup in PostHog dashboard"
+    ;;
+
+  dead-clicks-raw)
+    echo "=== Dead Clicks (Raw, Last 7 Days) ==="
+    curl -s -X POST "$BASE_URL/query" \
+      -H "Authorization: Bearer $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"query": {"kind": "HogQLQuery", "query": "SELECT count() AS c FROM events WHERE event = '"'"'$dead_click'"'"' AND timestamp > now() - INTERVAL 7 DAY"}}' \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); [print(f'count: {r[0]}') for r in d.get('results',[])]"
+    ;;
+
+  dead-clicks-real)
+    echo "=== Dead Clicks (Real / Filtered, Last 7 Days) ==="
+    curl -s -X POST "$BASE_URL/query" \
+      -H "Authorization: Bearer $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"query": {"kind": "HogQLQuery", "query": "SELECT count() AS c FROM events WHERE event = '"'"'$dead_click'"'"' AND coalesce(properties.$external_click_url, '"'"''"'"') NOT LIKE '"'"'%amzn%'"'"' AND coalesce(properties.$external_click_url, '"'"''"'"') NOT LIKE '"'"'%amazon%'"'"' AND coalesce(properties.$external_click_url, '"'"''"'"') NOT LIKE '"'"'%fullerhealth%'"'"' AND timestamp > now() - INTERVAL 7 DAY"}}' \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); [print(f'count: {r[0]}') for r in d.get('results',[])]"
     ;;
 
   *)
@@ -60,10 +78,12 @@ for e in d.get('results',[]):
     echo "Usage: $0 [command]"
     echo ""
     echo "Commands:"
-    echo "  events     - Show event counts by type"
-    echo "  scroll     - Show scroll depth events"
-    echo "  affiliate  - Show affiliate link clicks"
-    echo "  pageviews  - Show pageviews by path"
-    echo "  funnel     - Show conversion funnel (TBD)"
+    echo "  events            - Show event counts by type"
+    echo "  scroll            - Show scroll depth events"
+    echo "  affiliate         - Show affiliate link clicks"
+    echo "  pageviews         - Show pageviews by path"
+    echo "  funnel            - Show conversion funnel (TBD)"
+    echo "  dead-clicks-raw   - Total \$dead_click count (unfiltered, includes affiliate false-positives)"
+    echo "  dead-clicks-real  - \$dead_click count filtered to exclude Amazon/Fuller affiliate false-positives"
     ;;
 esac

--- a/scripts/utm-tag.sh
+++ b/scripts/utm-tag.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# UTM Tagging Helper for DHM Guide
+# Usage: ./scripts/utm-tag.sh <url> <channel> [campaign]
+#
+# See docs/posthog-analysis-2026-04-25/r10-utm-standard.md for full convention.
+
+set -euo pipefail
+
+URL="${1:-}"
+CHANNEL="${2:-}"
+CAMPAIGN="${3:-$(date +%Y-%m)}"
+
+if [ -z "$URL" ] || [ -z "$CHANNEL" ]; then
+  echo "Usage: $0 <url> <channel> [campaign]"
+  echo ""
+  echo "Channels: newsletter, x, linkedin, reddit, facebook, youtube, podcast"
+  echo "Campaign defaults to YYYY-MM ($(date +%Y-%m))"
+  echo ""
+  echo "Example:"
+  echo "  $0 https://www.dhmguide.com/reviews newsletter"
+  echo "  -> https://www.dhmguide.com/reviews?utm_source=newsletter&utm_medium=email&utm_campaign=$(date +%Y-%m)"
+  exit 1
+fi
+
+case "$CHANNEL" in
+  newsletter) SOURCE=newsletter; MEDIUM=email ;;
+  x|twitter)  SOURCE=x;          MEDIUM=social ;;
+  linkedin)   SOURCE=linkedin;   MEDIUM=social ;;
+  reddit)     SOURCE=reddit;     MEDIUM=social ;;
+  facebook)   SOURCE=facebook;   MEDIUM=social ;;
+  youtube)    SOURCE=youtube;    MEDIUM=video ;;
+  podcast)    SOURCE=podcast;    MEDIUM=audio ;;
+  *)
+    echo "Error: unknown channel '$CHANNEL'." >&2
+    echo "Supported: newsletter, x, linkedin, reddit, facebook, youtube, podcast" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$URL" == *\?* ]]; then
+  SEP="&"
+else
+  SEP="?"
+fi
+
+echo "${URL}${SEP}utm_source=${SOURCE}&utm_medium=${MEDIUM}&utm_campaign=${CAMPAIGN}"


### PR DESCRIPTION
(1) `scripts/posthog-query.sh` requires `POSTHOG_PERSONAL_API_KEY` from env, fails fast if unset. (2) `dead-clicks-raw`/`dead-clicks-real` subcommands filter Amazon/Fuller `target=_blank` false-positives at query time — better than globally disabling dead-click capture. (3) `scripts/utm-tag.sh` + UTM standard doc.

Refs #268.