### PR TITLE
fix: render full article HTML in prerender (remove cloaking pattern)

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,8 +265,10 @@
   </head>
   <body>
     <div id="root">
-      <!-- Initial content for crawlers while React loads -->
-      <div style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
+      <!-- Initial content for crawlers while React loads.
+           Issue #284: removed off-screen positioning (cloaking pattern).
+           React's createRoot replaces this on mount; visible briefly is fine. -->
+      <div>
         <h1>DHM Guide: Science-Backed Hangover Prevention</h1>
         <p>Discover how DHM (Dihydromyricetin) prevents hangovers with clinically-proven effectiveness. Based on 11+ scientific studies and UCLA research.</p>
         <p>Learn about proper DHM dosage, timing, and the best supplements for hangover prevention.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,8 @@
         "gray-matter": "^4.0.3",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.510.0",
+        "micromark": "^4.0.2",
+        "micromark-extension-gfm": "^3.0.0",
         "next-themes": "^0.4.6",
         "playwright": "^1.57.0",
         "posthog-js": "^1.311.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "gray-matter": "^4.0.3",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
+    "micromark": "^4.0.2",
+    "micromark-extension-gfm": "^3.0.0",
     "next-themes": "^0.4.6",
     "playwright": "^1.57.0",
     "posthog-js": "^1.311.0",

--- a/scripts/prerender-blog-posts-enhanced.js
+++ b/scripts/prerender-blog-posts-enhanced.js
@@ -10,6 +10,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import jsdom from 'jsdom';
+import { micromark } from 'micromark';
+import { gfm, gfmHtml } from 'micromark-extension-gfm';
 import { generateFAQSchema } from '../src/utils/productSchemaGenerator.js';
 import { generateHowToSchema } from '../src/utils/structuredDataHelpers.js';
 
@@ -290,10 +292,21 @@ async function prerenderPost(post, baseHtml, blogDistDir) {
     // Insert noscript content after root div
     rootDiv.insertAdjacentHTML('afterend', noscriptContent);
     
-    // Add visible initial content for SEO (removed display:none to prevent cloaking)
-    // This content will be replaced when React loads but is visible to crawlers
+    // Render full article body via micromark (issue #284: was a 100-word stub
+    // hidden off-screen — that pattern triggered Google cloaking penalty risk
+    // and starved AI crawlers of content). React's createRoot replaces this
+    // on hydration, so no mismatch concerns; crawlers see full text first.
+    const contentStr = typeof post.content === 'string' ? post.content : '';
+    const fullContentHtml = contentStr
+      ? micromark(contentStr, {
+          allowDangerousHtml: true,
+          extensions: [gfm()],
+          htmlExtensions: [gfmHtml()]
+        })
+      : '';
+
     rootDiv.innerHTML = `
-      <div id="prerender-content" style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
+      <div id="prerender-content">
         <article>
           <h1>${safeTitle}</h1>
           <div class="meta">
@@ -302,7 +315,7 @@ async function prerenderPost(post, baseHtml, blogDistDir) {
             <span>${escapeHtml(String(post.readTime))} min read</span>
           </div>
           <p class="excerpt">${safeExcerpt}</p>
-          ${safeFirstParagraph ? `<p>${safeFirstParagraph}</p>` : ''}
+          ${fullContentHtml}
         </article>
       </div>
     `;


### PR DESCRIPTION
Closes #284. **Keystone fix for EPIC #283.**

Removes the off-screen prerender stub (~100 words at `scripts/prerender-blog-posts-enhanced.js:296` and `index.html:269` styled `position: absolute; left: -9999px;`) — the canonical Google cloaking penalty signal. Replaces with full article HTML rendered via `micromark` + GFM extension (already transitive deps).

## Verified
- `npm run build` succeeds: 189 posts + 7 main pages prerendered
- `grep "left: -9999px" dist/` → 0 occurrences  
- `dhm-dosage-guide-2025` prerendered HTML: **103 `<p>` tags (was 0-1)**
- `flyby-vs-cheers` prerendered HTML: 42 `<p>` tags
- React uses `createRoot()` (`src/main.jsx:139`) so prerendered article replaced on hydration — no mismatch warnings
- Bingbot, GPTBot, ClaudeBot, PerplexityBot now see full article content (was ~100 words before)

## Why this matters
This blocked the entire master plan: AI search optimization, Bing/Copilot indexing, and Google's E-E-A-T signal evaluation all depend on crawlers being able to read article content. Mobile/Vercel serve full content; the cloaking penalty had been quietly priced into the site's rankings.

Refs #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)