### PR TITLE
fix: wire up newsletter capture to Buttondown serverless proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Newsletter (Buttondown) — server-side only, used by api/newsletter-subscribe.js.
+# Get your key at https://buttondown.email/settings/programmatic
+# Set in Vercel: Project → Settings → Environment Variables → BUTTONDOWN_API_KEY
+# Apply to: Production, Preview, Development.
+BUTTONDOWN_API_KEY=

--- a/api/newsletter-subscribe.js
+++ b/api/newsletter-subscribe.js
@@ -1,0 +1,79 @@
+// Vercel serverless function: proxies newsletter signups to Buttondown.
+// Keeps the API key server-side. Returns user-friendly errors.
+// Env required (Vercel Project Settings → Environment Variables): BUTTONDOWN_API_KEY
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const ALLOWED_SOURCES = new Set(['inline', 'exit_intent', 'unknown'])
+const BUTTONDOWN_URL = 'https://api.buttondown.email/v1/subscribers'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ ok: false, error: 'Method not allowed' })
+  }
+
+  // Vercel auto-parses JSON when Content-Type is application/json.
+  // Be defensive: also accept a string body.
+  let body = req.body
+  if (typeof body === 'string') {
+    try { body = JSON.parse(body) } catch { body = {} }
+  }
+  body = body || {}
+
+  const email = typeof body.email === 'string' ? body.email.trim() : ''
+  const sourceInput = typeof body.source === 'string' ? body.source : 'unknown'
+  const source = ALLOWED_SOURCES.has(sourceInput) ? sourceInput : 'unknown'
+
+  if (!EMAIL_REGEX.test(email)) {
+    return res.status(400).json({ ok: false, error: 'Invalid email address' })
+  }
+
+  const apiKey = process.env.BUTTONDOWN_API_KEY
+  if (!apiKey) {
+    console.error('[newsletter-subscribe] BUTTONDOWN_API_KEY missing')
+    return res.status(503).json({ ok: false, error: 'Newsletter service not configured' })
+  }
+
+  try {
+    const upstream = await fetch(BUTTONDOWN_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Token ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email_address: email,
+        tags: ['dhm-calculator'],
+        metadata: { source },
+      }),
+    })
+
+    if (upstream.status === 201 || upstream.status === 200) {
+      return res.status(200).json({ ok: true, status: 'subscribed' })
+    }
+
+    // Buttondown returns 400 with a code/message when the email is already on the list.
+    // Treat that as success from the user's POV.
+    if (upstream.status === 400) {
+      const text = await upstream.text()
+      if (/already|exists|duplicate/i.test(text)) {
+        return res.status(200).json({ ok: true, status: 'already_subscribed' })
+      }
+      return res.status(400).json({ ok: false, error: 'Invalid request' })
+    }
+
+    if (upstream.status >= 500) {
+      const text = await upstream.text().catch(() => '')
+      console.error('[newsletter-subscribe] Buttondown 5xx', upstream.status, text)
+      return res.status(502).json({ ok: false, error: 'Newsletter service unavailable' })
+    }
+
+    // 401/403/etc — auth/key problem. Don't leak details to the client.
+    const text = await upstream.text().catch(() => '')
+    console.error('[newsletter-subscribe] Buttondown unexpected', upstream.status, text)
+    return res.status(502).json({ ok: false, error: 'Newsletter service unavailable' })
+  } catch (err) {
+    console.error('[newsletter-subscribe] fetch threw', err)
+    return res.status(502).json({ ok: false, error: 'Newsletter service unavailable' })
+  }
+}

--- a/specs/issue-285-newsletter/design.md
+++ b/specs/issue-285-newsletter/design.md
@@ -1,0 +1,96 @@
+# Design: Newsletter Capture Wire-up (Issue #285)
+
+## Architecture
+
+```
+[browser]
+  DosageCalculatorEnhanced.jsx
+    └─ handleEmailCapture(email)
+         └─ fetch('/api/newsletter-subscribe', { method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, source }) })
+                                |
+                                v
+[vercel serverless]
+  api/newsletter-subscribe.js
+    1. Validate method is POST
+    2. Parse + validate email regex
+    3. Read BUTTONDOWN_API_KEY (return 503 if missing)
+    4. POST to https://api.buttondown.email/v1/subscribers
+         Authorization: Token <key>
+         body: { email_address, tags: ["dhm-calculator"], metadata: { source } }
+    5. Map upstream response → client-friendly status
+                                |
+                                v
+[client]
+  - 2xx → sonner toast success, setEmailCaptured(true), trackEvent('newsletter_subscribe_succeeded')
+  - 4xx/5xx → sonner toast error, leave form open, trackEvent('newsletter_subscribe_failed')
+```
+
+## File-by-file plan
+
+### NEW: `api/newsletter-subscribe.js` (~50 lines)
+Vercel serverless function (Node runtime, default). Exports default handler `(req, res) => {}`.
+
+Logic:
+1. Reject non-POST with 405.
+2. Parse `req.body` (Vercel auto-parses JSON when Content-Type is application/json).
+3. Validate `email` against simple regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`. Return 400 if invalid.
+4. Validate `source` is in `['inline','exit_intent','unknown']`; default `'unknown'`.
+5. If `process.env.BUTTONDOWN_API_KEY` is missing → 503 `{ error: "Newsletter service not configured" }`.
+6. `fetch('https://api.buttondown.email/v1/subscribers', { method: 'POST', headers: { 'Authorization': \`Token ${key}\`, 'Content-Type': 'application/json' }, body: JSON.stringify({ email_address: email, tags: ['dhm-calculator'], metadata: { source } }) })`
+7. If upstream `res.status === 201` → 200 `{ ok: true, status: 'subscribed' }`.
+8. If upstream `res.status === 400` AND body contains "already" → 200 `{ ok: true, status: 'already_subscribed' }`.
+9. Other 4xx → return upstream status with `{ ok: false, error: "Invalid request" }`.
+10. 5xx or thrown → 502 `{ ok: false, error: "Newsletter service unavailable" }`. Log to Vercel via `console.error`.
+
+### MODIFY: `src/pages/DosageCalculatorEnhanced.jsx`
+Replace `handleEmailCapture` body (lines 730-750):
+- Add `try/catch` around fetch to `/api/newsletter-subscribe`.
+- Use sonner `toast.success` / `toast.error` from `import { toast } from 'sonner'`.
+- Track new PostHog events. Reuse existing `trackEvent` import (already imported per `trackEvent('calculator_form_submitted', ...)` at line 670).
+- Only setEmailCaptured(true) on success (so user can retry on failure).
+
+Add toast import at top: `import { toast } from 'sonner'`.
+
+### MODIFY: `src/main.jsx` (only if Toaster not mounted)
+Verify `<Toaster />` is mounted globally. If not, add it.
+
+### NEW: `.env.example`
+Document `BUTTONDOWN_API_KEY=` placeholder. Tracked by git so contributors know which envs to set.
+
+## Error-handling matrix
+
+| Failure | HTTP from function | Client behavior |
+|---|---|---|
+| Non-POST | 405 | Won't happen via UI; defensive only |
+| Invalid email | 400 | Toast: "That email looks invalid" |
+| Missing env var | 503 | Toast: "Couldn't reach our newsletter service" |
+| Buttondown 5xx | 502 | Toast: "Couldn't reach our newsletter service" |
+| Buttondown auth fail (401) | 502 | Same as above (admin sees `console.error` in Vercel logs) |
+| Already subscribed | 200 (mapped) | Toast success — same UX as new subscribe |
+| Network error (offline) | n/a (fetch throws) | Caught by client `try/catch`, toast error |
+
+## Security
+- **API key**: only in `process.env.BUTTONDOWN_API_KEY` on Vercel. Never imported in client code. `.env.example` contains only the var name with empty value.
+- **CORS**: not needed — function is same-origin (`https://www.dhmguide.com/api/*`).
+- **CSP impact**: zero — no new third-party domains exposed to the client. All Buttondown traffic is server-to-server.
+- **Rate limiting**: rely on Buttondown's upstream rate limit. If abuse appears, add a per-IP throttle later (not in scope).
+- **Input validation**: simple regex client-side AND server-side (defense in depth). No HTML rendering of user input anywhere.
+- **PII**: email is sent to Buttondown only. No logging of emails on our side.
+
+## Rollback
+Single PR revert. Reverts:
+- Removes `api/newsletter-subscribe.js`.
+- Restores `handleEmailCapture` to console.log + alert().
+- Removes sonner toast import (if not used elsewhere — verify).
+- Removes `.env.example`.
+
+No DB, no migrations, no deploy-time side effects. Worst case: emails go back to being dropped (status quo).
+
+## Out of scope (deferred)
+- Double opt-in confirmation emails (Buttondown handles this in their dashboard).
+- Subscriber tagging beyond `dhm-calculator` (single tag is enough for v1).
+- Migrations of historical signups (none exist — emails were never persisted).
+- A/B testing copy variants of the toast.
+- Per-IP rate limiting (Buttondown handles enough for v1).

--- a/specs/issue-285-newsletter/plan.md
+++ b/specs/issue-285-newsletter/plan.md
@@ -1,0 +1,21 @@
+# [Phase 1] Wire up newsletter capture — emails being dropped into a TODO
+
+Refs #283. Email-capture UX wired up but integration was never connected.
+
+## Problem
+`src/pages/DosageCalculatorEnhanced.jsx:566, 730` capture emails. Line 747:
+```js
+// TODO: Integrate with Formspree or ConvertKit (Issue #180)
+```
+Every signup since launch has been silently dropped.
+
+## Fix (~2-4 hrs)
+1. Pick ESP (Buttondown $9/mo, simple — recommend; or ConvertKit)
+2. Add `api/newsletter-subscribe.js` Vercel serverless (~30 lines, proxies to Buttondown's `/v1/subscribers`, keeps API key server-side)
+3. Wire `DosageCalculatorEnhanced.jsx:747` to POST to it
+4. Set `BUTTONDOWN_API_KEY` in Vercel env
+
+## Source
+`docs/traffic-growth-2026-04-26/synthesis-S1-critical-fires.md` Fire #2.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-285-newsletter/requirements.md
+++ b/specs/issue-285-newsletter/requirements.md
@@ -1,0 +1,65 @@
+# Requirements: Newsletter Capture Wire-up (Issue #285)
+
+## Problem statement
+The DHM dosage calculator at `/dhm-dosage-calculator` collects emails via two UX surfaces (inline form + exit-intent popup) but the submit handler `handleEmailCapture` only logs to console and shows a placeholder `alert()`. Every newsletter signup since the calculator launched has been silently dropped. The TODO at `src/pages/DosageCalculatorEnhanced.jsx:747` traces back to Issue #180 (never closed).
+
+This blocks downstream traffic-growth plans (referenced in `docs/traffic-growth-2026-04-26/synthesis-S1-critical-fires.md` Fire #2) that depend on a working email list.
+
+## User stories
+
+### US-1: Visitor receives confirmation that signup worked
+**As a** visitor who entered my email,
+**I want** clear feedback that I'm subscribed,
+**So that** I trust the signup and don't try again.
+
+**Acceptance criteria**
+- AC1.1 On 2xx from `/api/newsletter-subscribe`, a success toast appears: "Subscribed — check your inbox for your DHM guide."
+- AC1.2 The form/popup closes; `emailCaptured` flips to `true`; the value-prop card hides.
+- AC1.3 No browser `alert()` anywhere in the flow.
+
+### US-2: Visitor sees a real error if signup fails
+**As a** visitor whose request failed,
+**I want** an actionable error message,
+**So that** I can retry or know to contact support.
+
+**Acceptance criteria**
+- AC2.1 On 4xx (validation), toast says: "That email looks invalid — please check and try again." Form stays open.
+- AC2.2 On 5xx / network failure, toast says: "Couldn't reach our newsletter service — please try again in a minute." Form stays open.
+- AC2.3 If email is already subscribed (Buttondown returns 400 with that signal), treat as success from user's POV.
+
+### US-3: Newsletter owner has emails captured in Buttondown
+**As the** site owner,
+**I want** captured emails to land in Buttondown with a tag identifying the source,
+**So that** I can broadcast to calculator subscribers.
+
+**Acceptance criteria**
+- AC3.1 Successful POST creates a Buttondown subscriber with `tags: ["dhm-calculator"]` and `metadata.source: "<inline|exit_intent>"`.
+- AC3.2 Buttondown API key never appears in client bundle, git history, or browser network tab.
+- AC3.3 Function works in production once `BUTTONDOWN_API_KEY` is set in Vercel env.
+
+### US-4: Function fails gracefully when env var is missing (dev/preview)
+**As a** developer running locally without `BUTTONDOWN_API_KEY` set,
+**I want** the function to return a clear error instead of crashing,
+**So that** I can debug other features without setting up an ESP account.
+
+**Acceptance criteria**
+- AC4.1 Missing env var: function returns 503 with `{ error: "Newsletter service not configured" }`.
+- AC4.2 Client shows the same generic 5xx toast (US-2.2).
+
+### US-5: Successful captures are visible in PostHog
+**As an** analyst,
+**I want** to differentiate "form submitted" from "ESP confirmed delivery",
+**So that** I can detect ESP outages.
+
+**Acceptance criteria**
+- AC5.1 `engagementTracker.trackEmailCapture(source)` continues to fire on submit (already wired).
+- AC5.2 New PostHog event `newsletter_subscribe_succeeded` fires on 2xx with `{ source, esp: "buttondown" }`.
+- AC5.3 New PostHog event `newsletter_subscribe_failed` fires on 4xx/5xx with `{ source, status, esp }`.
+
+## Quality requirements
+- **Build**: `npm run build` must pass (validates posts, sitemap, prerender).
+- **No secrets in code**: `BUTTONDOWN_API_KEY` only via `process.env` in serverless function.
+- **No breakage**: existing tracking (`trackEmailCapture`, `setEmailCaptured`) still fires.
+- **Bundle size**: client-side delta < 1 KB gzip (sonner already in deps).
+- **Rollback**: single PR revert restores prior behavior.
+- **Test plan**: manually POST to function with curl in preview; verify 503 path locally without env var.

--- a/specs/issue-285-newsletter/research.md
+++ b/specs/issue-285-newsletter/research.md
@@ -1,0 +1,83 @@
+# Research: Newsletter Capture Wire-up (Issue #285)
+
+## Current State
+
+### Email capture flow
+`src/pages/DosageCalculatorEnhanced.jsx` collects emails in two places:
+
+1. **Inline post-results form** (~line 1495-1565): renders only when `!emailCaptured`. Form submit calls `handleEmailCapture(email)` (line 1544).
+2. **Exit-intent popup** (`ExitIntentPopup`, line 176-277): shown when mouse leaves viewport AND user has interacted >10s. Submit calls `onSubmit(email)`, wired to `handleEmailCapture` at line 777.
+
+Both flows funnel through one handler at line 730:
+
+```jsx
+const handleEmailCapture = async (capturedEmail) => {
+  setEmail(capturedEmail)
+  setEmailCaptured(true)
+  setShowExitIntent(false)
+  const source = showExitIntent ? 'exit_intent' : 'inline'
+  engagementTracker.trackEmailCapture(source)
+  console.log('Email capture attempt:', capturedEmail, 'source:', source)
+  if (isMobile) hapticFeedback('success')
+  // TODO: Integrate with Formspree or ConvertKit (Issue #180)
+  alert('Thanks for your interest! Our email system is being set up...')
+}
+```
+
+The `alert()` confirms the bug: emails are logged to console only. Every signup since launch has been dropped.
+
+### Repo conventions
+- **No `api/` directory exists** — this will be the first Vercel serverless function.
+- **`vercel.json`** has rewrites (PostHog ingest proxy, SPA fallback) but NO `functions` config. Vercel auto-detects `api/*.js` files at the project root.
+- **Notable**: rewrite `/((?!never-hungover/).*)` -> `/index.html` would conflict with `/api/*` if not excluded. Confirmed exclusion via `((?!api/).*)/` redirect rule (line 12-14) — but the SPA fallback rewrite does NOT exclude api. Need to verify API routes still work; Vercel routes API requests before SPA rewrites by convention. Test: confirmed safe in Vercel docs (function routes take precedence over rewrites for same-origin).
+- **PostHog proxy at `/ingest/*`** uses Vercel rewrites with CORS headers. Same pattern works for our function.
+- **Build script** validates posts, generates sitemap, then `vite build`. No backend bundling; serverless functions are deployed independently by Vercel.
+- **Existing dep `sonner` (^2.0.3)**: toast library already installed — use for success/error feedback instead of `alert()`.
+
+### Tracking
+`engagementTracker.trackEmailCapture(source)` already fires PostHog event regardless of ESP success. We'll add a follow-up event for ESP success/failure to differentiate captured vs delivered.
+
+## ESP Options Analyzed
+
+| ESP | Pricing | API ergonomics | Verdict |
+|---|---|---|---|
+| **Buttondown** | $9/mo first 100, scales linearly | Single API key, `POST /v1/subscribers` with `{email_address}`. Simple JSON. Owner-friendly product (writer/dev focus). | **Recommended.** Lowest friction for indie blog/newsletter. |
+| ConvertKit (now Kit) | Free up to 10k subs, $29/mo above | API key + form_id + tag_id required. More fields. Better for marketers with sequences/automations. | Overkill for a single capture. |
+| Formspree | Free up to 50/mo, $15/mo | Just receives forms — no broadcast capability. Would still need a separate ESP later. | Defers the real problem. |
+| Mailchimp | $13/mo+ | API requires audience_id (list_id), MD5-hashed email for upsert. Heavier integration. | Heavier than needed. |
+
+### Choice: Buttondown
+1. **Simplest API** — one POST, one key, no list_id juggling.
+2. **Cheapest** at our scale ($9/mo).
+3. **Owner can send broadcasts** without a CRM-style learning curve.
+4. **Single-key auth** keeps the serverless function under 30 lines.
+5. Spec hint also pre-recommended Buttondown; no contrary signal in research.
+
+## Architecture
+```
+Browser form submit
+    -> POST /api/newsletter-subscribe { email }
+       -> serverless function reads BUTTONDOWN_API_KEY env
+       -> POST https://api.buttondown.email/v1/subscribers
+         Authorization: Token <key>
+         body: { email_address: <email>, tags: ["dhm-calculator"] }
+       -> returns 201 (new) | 200 (already subscribed) | 4xx (error)
+    -> client shows toast (sonner) + sets emailCaptured=true
+```
+
+Function is ~30 lines. Single try/catch. Buttondown returns idempotent results — if email already subscribed it returns 400 with a parseable error, which we treat as success from the user's POV ("already subscribed — thanks!").
+
+## Risk register
+- **Missing env var in dev**: function returns 503 with friendly message; client shows error toast.
+- **Buttondown 5xx**: log to console (Vercel logs), return 502 to client, show retry-able error.
+- **Rate limit / abuse**: Buttondown handles. We add a basic email regex check before the upstream call.
+- **CORS**: same-origin (`/api/*` on same domain), no CORS config needed.
+- **No bundle-size impact**: function is server-side; client only adds a tiny fetch + toast import.
+
+## Files to touch
+- **NEW** `api/newsletter-subscribe.js` — Vercel serverless proxy
+- **NEW** `.env.example` — document `BUTTONDOWN_API_KEY`
+- **MODIFY** `src/pages/DosageCalculatorEnhanced.jsx` — replace alert with fetch + toast
+- **MODIFY** `src/main.jsx` (if needed) — mount `<Toaster />` from sonner if not already mounted
+
+Verify Toaster mount status during execute.

--- a/specs/issue-285-newsletter/tasks.md
+++ b/specs/issue-285-newsletter/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Newsletter Capture Wire-up (Issue #285)
+
+10 fine-grained tasks. Each: file path, action, verify command.
+
+## T1. Create serverless function file
+- **File**: `api/newsletter-subscribe.js` (NEW; will trigger creation of `api/` dir)
+- **Action**: Write Vercel default-export handler. POST-only. Validates email regex. Returns 503 if `BUTTONDOWN_API_KEY` missing. Proxies to `https://api.buttondown.email/v1/subscribers` with `Authorization: Token <key>`. Maps upstream 201/400(already-subscribed) → 200; other 4xx pass through; 5xx → 502.
+- **Verify**: `node -e "require('./api/newsletter-subscribe.js')"` (basic require parse) — but ESM, so use `node --input-type=module -e "import('./api/newsletter-subscribe.js').then(m => console.log(typeof m.default))"`. Expect `function`.
+
+## T2. Verify Toaster is mounted globally
+- **File**: `src/main.jsx` (or `src/App.jsx`)
+- **Action**: Search for `<Toaster` — if missing, import `{ Toaster }` from `sonner` and mount once near the root.
+- **Verify**: `grep -rn "Toaster" src/main.jsx src/App.jsx`
+
+## T3. Import toast in calculator page
+- **File**: `src/pages/DosageCalculatorEnhanced.jsx`
+- **Action**: Add `import { toast } from 'sonner'` to the existing imports block at the top.
+- **Verify**: `grep -n "from 'sonner'" src/pages/DosageCalculatorEnhanced.jsx`
+
+## T4. Replace handleEmailCapture body
+- **File**: `src/pages/DosageCalculatorEnhanced.jsx` lines 730-750
+- **Action**: Replace `alert()` with `fetch('/api/newsletter-subscribe', POST)`; wire toast success/error; only `setEmailCaptured(true)` on 2xx; fire `trackEvent('newsletter_subscribe_succeeded' | 'newsletter_subscribe_failed', { source, ... })`.
+- **Verify**: `grep -n "newsletter-subscribe\|toast.success\|toast.error" src/pages/DosageCalculatorEnhanced.jsx`
+
+## T5. Verify trackEvent is imported
+- **File**: `src/pages/DosageCalculatorEnhanced.jsx`
+- **Action**: Confirm `trackEvent` is imported (already used line 670). If not, add it.
+- **Verify**: `grep -n "trackEvent" src/pages/DosageCalculatorEnhanced.jsx | head -3`
+
+## T6. Create .env.example
+- **File**: `.env.example` (NEW at project root)
+- **Action**: Document `BUTTONDOWN_API_KEY=` with an inline comment about where to get it and which Vercel env to set.
+- **Verify**: `cat .env.example`
+
+## T7. Build passes
+- **File**: n/a
+- **Action**: Run `npm run build`.
+- **Verify**: exit code 0; `dist/` exists; no errors about missing imports or `Toaster`.
+
+## T8. Static check on serverless function
+- **File**: `api/newsletter-subscribe.js`
+- **Action**: Visually verify no `BUTTONDOWN_API_KEY` is hardcoded; no client-only imports (no React, no `import.meta.env`); only `process.env`.
+- **Verify**: `grep -n "process.env.BUTTONDOWN_API_KEY" api/newsletter-subscribe.js`; `grep -n "import.meta\|react" api/newsletter-subscribe.js` — must return nothing.
+
+## T9. Commit on branch
+- **File**: git
+- **Action**: `git add` only the spec files + new code + `.env.example`. Commit with reference to #285 / #283.
+- **Verify**: `git log -1 --stat`
+
+## T10. Open PR + admin-merge
+- **File**: GitHub
+- **Action**: `gh pr create` with title `fix: wire up newsletter capture to Buttondown serverless proxy`, body containing `Closes #285. Refs #283.` + USER ACTION block (Buttondown account + Vercel env). Then `gh pr merge --squash --delete-branch --admin`.
+- **Verify**: `gh pr view --json state,mergedAt`; expect `MERGED`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense, useEffect } from 'react'
 import Layout from './components/layout/Layout.jsx'
 import { SpeedInsights } from '@vercel/speed-insights/react'
+import { Toaster } from 'sonner'
 import { useRouter } from './hooks/useRouter'
 import { initPostHog } from './lib/posthog'
 import { useAffiliateTracking } from './hooks/useAffiliateTracking'
@@ -91,6 +92,7 @@ function App() {
         {renderPage()}
       </Suspense>
       <SpeedInsights />
+      <Toaster position="top-center" richColors />
     </Layout>
   )
 }

--- a/src/pages/DosageCalculatorEnhanced.jsx
+++ b/src/pages/DosageCalculatorEnhanced.jsx
@@ -10,6 +10,7 @@ import { useSEO } from '../hooks/useSEO.js'
 import { useMobileOptimization } from '../hooks/useMobileOptimization.js'
 import engagementTracker from '../utils/engagement-tracker.js'
 import { trackEvent } from '../lib/posthog'
+import { toast } from 'sonner'
 import RelatedCalculators from '../components/RelatedCalculators.jsx'
 import { 
   Calculator,
@@ -729,24 +730,66 @@ export default function DosageCalculatorEnhanced() {
 
   const handleEmailCapture = async (capturedEmail) => {
     setEmail(capturedEmail)
-    setEmailCaptured(true)
-    setShowExitIntent(false)
-
-    // Track email capture attempt (even without ESP integration)
+    // Capture source BEFORE we close the popup, since showExitIntent flips below.
     const source = showExitIntent ? 'exit_intent' : 'inline'
+
+    // Existing PostHog event for "user attempted to subscribe" — keep firing regardless of ESP outcome.
     engagementTracker.trackEmailCapture(source)
 
-    // Log for future ESP integration
-    console.log('Email capture attempt:', capturedEmail, 'source:', source)
+    try {
+      const res = await fetch('/api/newsletter-subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: capturedEmail, source }),
+      })
 
-    // Haptic feedback
-    if (isMobile) {
-      hapticFeedback('success')
+      let payload = null
+      try { payload = await res.json() } catch { payload = null }
+
+      if (res.ok && payload && payload.ok) {
+        setEmailCaptured(true)
+        setShowExitIntent(false)
+        if (isMobile) hapticFeedback('success')
+
+        trackEvent('newsletter_subscribe_succeeded', {
+          source,
+          esp: 'buttondown',
+          status: payload.status || 'subscribed',
+          page_path: window.location.pathname,
+        })
+
+        toast.success('Subscribed — check your inbox for your DHM guide.')
+        return
+      }
+
+      // Failure path: keep form open so user can retry.
+      const status = res.status
+      const errorMessage = (payload && payload.error) || 'Subscription failed'
+
+      trackEvent('newsletter_subscribe_failed', {
+        source,
+        esp: 'buttondown',
+        status,
+        error: errorMessage,
+        page_path: window.location.pathname,
+      })
+
+      if (status === 400) {
+        toast.error('That email looks invalid — please check and try again.')
+      } else {
+        toast.error("Couldn't reach our newsletter service — please try again in a minute.")
+      }
+    } catch (err) {
+      console.error('newsletter subscribe failed:', err)
+      trackEvent('newsletter_subscribe_failed', {
+        source,
+        esp: 'buttondown',
+        status: 0,
+        error: 'network',
+        page_path: window.location.pathname,
+      })
+      toast.error("Couldn't reach our newsletter service — please try again in a minute.")
     }
-
-    // TODO: Integrate with Formspree or ConvertKit (Issue #180)
-    // For now, show honest message - email system coming soon
-    alert('Thanks for your interest! Our email system is being set up. Bookmark this page to return for your personalized DHM guide.')
   }
 
   const scrollToCalculator = () => {


### PR DESCRIPTION
Closes #285. Refs #283.

## Summary
- Adds `api/newsletter-subscribe.js` Vercel serverless function that proxies signups to Buttondown's `/v1/subscribers`. API key stays server-side.
- Wires `DosageCalculatorEnhanced.jsx` (`handleEmailCapture`) to POST `{ email, source }` to the function. Replaces the `alert()` placeholder and `console.log()` with `sonner` toasts.
- Mounts `<Toaster />` once in `App.jsx`.
- Adds new PostHog events to differentiate captured from delivered: `newsletter_subscribe_succeeded`, `newsletter_subscribe_failed`. Existing `engagementTracker.trackEmailCapture` event preserved.
- Adds `.env.example` documenting `BUTTONDOWN_API_KEY`.
- ESP choice: **Buttondown** ($9/mo, single-key API, simplest possible integration; cheaper and lower-friction than ConvertKit/Mailchimp). Rationale + alternatives in `specs/issue-285-newsletter/research.md`.

## Why this matters
Every email collected via the dosage calculator's inline form and exit-intent popup since launch was silently dropped. The TODO at `DosageCalculatorEnhanced.jsx:747` traces back to Issue #180.

## Behavior
| Path | Result |
|------|--------|
| Valid email + 201 from Buttondown | Toast: "Subscribed — check your inbox for your DHM guide." Form closes. |
| Valid email, already subscribed (Buttondown 400 with "already") | Same success toast — UX-equivalent. |
| Invalid email (server 400) | Toast: "That email looks invalid — please check and try again." Form stays open. |
| Missing `BUTTONDOWN_API_KEY` env var (server 503) | Toast: "Couldn't reach our newsletter service…" Form stays open. Logged via `console.error` to Vercel. |
| Buttondown 5xx / network error | Toast: "Couldn't reach our newsletter service…" Form stays open. |

## USER ACTION REQUIRED before this works in production
1. **Sign up for Buttondown** at https://buttondown.email (the $9/mo "Hobby" plan is sufficient).
2. **Get the API key** at https://buttondown.email/settings/programmatic.
3. **Add to Vercel**: Project → Settings → Environment Variables → add `BUTTONDOWN_API_KEY` with the value. Apply to **Production**, **Preview**, and (optionally) **Development**.
4. Trigger a redeploy (push any commit, or hit "Redeploy" in Vercel) so the function picks up the env var.
5. After it's live, send a test signup at https://www.dhmguide.com/dhm-dosage-calculator — fill the calculator, submit any email at the result, confirm it arrives in your Buttondown subscriber list.

Until step 3 is done, the function returns a friendly 503 and the user sees an error toast (no crash, no silent drop).

## Test plan
- [x] `npm run build` passes
- [x] Function module imports cleanly; `default export` is a function
- [x] GET → 405; POST invalid email → 400; POST valid + missing env → 503; POST string body parsed correctly
- [x] No `BUTTONDOWN_API_KEY` ends up in `dist/` (client bundle clean)
- [ ] Post-merge: confirm deployment, set Vercel env, test live signup, verify subscriber appears in Buttondown
- [ ] Verify PostHog `newsletter_subscribe_succeeded` event fires after live signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)