### PR TITLE
feat: filter bot traffic from LCP measurement (#287)

### DIFF
--- a/scripts/posthog-query.sh
+++ b/scripts/posthog-query.sh
@@ -73,6 +73,30 @@ for e in d.get('results',[]):
       | python3 -c "import json,sys; d=json.load(sys.stdin); [print(f'count: {r[0]}') for r in d.get('results',[])]"
     ;;
 
+  # Desktop LCP shows ~22s avg in raw data, but 81.5% of samples are a single
+  # headless-Chrome bot (Chrome/145.0.0.0, screen 800x600, viewport 1920, all
+  # entering via www.google.com referrer — almost certainly Google's SERP
+  # preview crawler). This subcommand splits real users from that bot so the
+  # real-user numbers aren't masked.
+  # See specs/issue-287-lcp-investigation/research.md for full evidence.
+  lcp-real)
+    echo "=== Desktop LCP — real users vs suspect bot (last 7 days) ==="
+    curl -s -X POST "$BASE_URL/query" \
+      -H "Authorization: Bearer $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"query": {"kind": "HogQLQuery", "query": "SELECT CASE WHEN properties.$raw_user_agent LIKE '"'"'%Chrome/145.0.0.0%'"'"' AND properties.$screen_width = 800 AND properties.$screen_height = 600 AND properties.$viewport_width = 1920 THEN '"'"'bot_chrome145_800x600'"'"' ELSE '"'"'real_user'"'"' END AS cohort, count() AS samples, avg(properties.$web_vitals_LCP_value) AS avg_ms, quantile(0.5)(properties.$web_vitals_LCP_value) AS p50_ms, quantile(0.75)(properties.$web_vitals_LCP_value) AS p75_ms, quantile(0.95)(properties.$web_vitals_LCP_value) AS p95_ms FROM events WHERE event = '"'"'$web_vitals'"'"' AND timestamp > now() - INTERVAL 7 DAY AND properties.$device_type = '"'"'Desktop'"'"' AND properties.$web_vitals_LCP_value IS NOT NULL GROUP BY cohort ORDER BY cohort ASC"}}' \
+      | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+rows = d.get('results', [])
+print(f'{\"cohort\":<28} {\"samples\":>8} {\"avg_s\":>8} {\"p50_s\":>8} {\"p75_s\":>8} {\"p95_s\":>8}')
+for r in rows:
+    cohort, n, avg, p50, p75, p95 = r
+    print(f'{cohort:<28} {n:>8} {avg/1000:>8.2f} {p50/1000:>8.2f} {p75/1000:>8.2f} {p95/1000:>8.2f}')
+print()
+print('Note: Google\\'s \"good\" LCP threshold is 2.5s. Real-user p50 is the headline number.')"
+    ;;
+
   *)
     echo "PostHog Query Helper"
     echo "Usage: $0 [command]"
@@ -85,5 +109,6 @@ for e in d.get('results',[]):
     echo "  funnel            - Show conversion funnel (TBD)"
     echo "  dead-clicks-raw   - Total \$dead_click count (unfiltered, includes affiliate false-positives)"
     echo "  dead-clicks-real  - \$dead_click count filtered to exclude Amazon/Fuller affiliate false-positives"
+    echo "  lcp-real          - Desktop LCP split between real users and the SERP-preview bot (filters Chrome/145 + 800x600 screen)"
     ;;
 esac

--- a/specs/issue-287-lcp-investigation/design.md
+++ b/specs/issue-287-lcp-investigation/design.md
@@ -1,0 +1,51 @@
+# Design — Issue #287: `lcp-real` Subcommand
+
+## Approach
+Add a single `case` branch to `scripts/posthog-query.sh` that runs a HogQL query splitting desktop `$web_vitals` events into `bot` and `real` cohorts, then printing a small comparison table.
+
+Follow the existing pattern (cf. `dead-clicks-real`): one HogQL query, a python3 one-liner to format output, no new dependencies.
+
+## HogQL Query
+```sql
+SELECT
+  CASE
+    WHEN properties.$raw_user_agent LIKE '%Chrome/145.0.0.0%'
+         AND properties.$screen_width = 800
+         AND properties.$screen_height = 600
+         AND properties.$viewport_width = 1920
+    THEN 'bot_chrome145_800x600'
+    ELSE 'real_user'
+  END AS cohort,
+  count() AS samples,
+  avg(properties.$web_vitals_LCP_value) AS avg_lcp_ms,
+  quantile(0.5)(properties.$web_vitals_LCP_value) AS p50_ms,
+  quantile(0.75)(properties.$web_vitals_LCP_value) AS p75_ms,
+  quantile(0.95)(properties.$web_vitals_LCP_value) AS p95_ms
+FROM events
+WHERE event = '$web_vitals'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND properties.$device_type = 'Desktop'
+  AND properties.$web_vitals_LCP_value IS NOT NULL
+GROUP BY cohort
+```
+
+## Why this filter (and not something tighter/looser)
+- **UA + screen-size combo** = three independent signals all matching uniformly across 154 samples. Almost zero false-positive risk on real users (the 800×600 screen with 1920 viewport is impossible on a real Windows desktop).
+- Filtering by UA alone (`Chrome/145`) might catch a small number of real users on stale Chrome — adding the screen-size guard prevents that.
+- Filtering by referrer (`www.google.com`) would over-block real Google-organic users.
+
+## Output Format
+```
+=== Desktop LCP — real users vs suspect bot (last 7 days) ===
+cohort                          samples    avg_s    p50_s    p75_s    p95_s
+real_user                            35     2.28     1.99     2.84     5.75
+bot_chrome145_800x600               154    20.88    21.70    34.25    45.95
+```
+
+## Risk
+Low. Pure additive change to a CLI helper. No production code path touched. If the bot's UA changes (e.g., Chrome 146 next month), the filter goes stale — that's fine; the script just stops cleanly separating cohorts and we update the version string.
+
+## Files Touched
+- `scripts/posthog-query.sh` — add `lcp-real)` case + line in help.
+
+That's it. ~20 lines of bash.

--- a/specs/issue-287-lcp-investigation/plan.md
+++ b/specs/issue-287-lcp-investigation/plan.md
@@ -1,0 +1,14 @@
+# [Phase 1] Investigate desktop LCP regression — 22.4s avg
+
+Refs #283. Desktop LCP averages 22.4s for ~70% of measured sessions; mobile is fine (1.2s).
+
+## Investigate first (~2 hrs)
+T8 hints 70% may be bot traffic. Run HogQL on `$web_vitals` segmented by user-agent + per-page. Determine real-user vs bot share before bundle work.
+
+## Fix only if real users (~2-4 hrs)
+Hero image weight, render-blocking JS, font-loading. Note: Phase 1 cloaking fix likely halves LCP on its own — re-measure after that lands.
+
+## Source
+`docs/traffic-growth-2026-04-26/synthesis-S1-critical-fires.md` Fire #4.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-287-lcp-investigation/requirements.md
+++ b/specs/issue-287-lcp-investigation/requirements.md
@@ -1,0 +1,34 @@
+# Requirements — Issue #287: Filter Bot Traffic from LCP Measurement
+
+## Problem
+PostHog reports desktop LCP averaging 22.4s, looking like a critical performance regression. Investigation (see `research.md`) shows 81.5% of desktop `$web_vitals` samples come from a single headless-Chrome bot (Chrome 145, screen 800x600, viewport 1920, `www.google.com` referrer). Real-user desktop p50 LCP is **1.99s** — well within Google's "good" threshold.
+
+## Goal
+Stop the bot from poisoning our LCP reporting so future audits return real-user numbers without manual filtering.
+
+## Functional Requirements
+
+### FR-1: New `posthog-query.sh lcp-real` subcommand
+- Reports real-user desktop LCP (samples, avg, p50, p75, p95) over the last 7 days.
+- Excludes events matching the bot fingerprint:
+  - `$device_type = 'Desktop'`
+  - `$raw_user_agent LIKE '%Chrome/145.0.0.0%'`
+  - `$screen_width = 800` AND `$screen_height = 600` AND `$viewport_width = 1920`
+- Reports the bot cohort separately (samples + avg LCP) for transparency.
+- Help text in the script's `*)` case lists the new command.
+
+### FR-2: Document the bot signature
+- Research findings written to `specs/issue-287-lcp-investigation/research.md` (done).
+- A short comment in `scripts/posthog-query.sh` next to the new subcommand explains what's being filtered and why.
+
+## Non-Goals (explicitly OUT of scope)
+- No code-performance changes (hero images, render-blocking JS, font-loading) — real users are fine.
+- No PostHog dashboard config changes (saved insights/filters live in PostHog UI; out of repo scope).
+- No SDK-level bot-blocking via `before_send` — too risky to ship without testing, and a single CLI helper meets the immediate need.
+- No backfill / event deletion — historical bot data stays in PostHog; we just filter at query time.
+
+## Acceptance Criteria
+- `./scripts/posthog-query.sh lcp-real` runs and prints a table showing real-user vs bot cohorts.
+- Real-user cohort p50 displays under 2.5s (Google "good" threshold) given current data.
+- `./scripts/posthog-query.sh` (no args) help output includes `lcp-real` in the command list.
+- `research.md` clearly documents the bot fingerprint so this isn't re-investigated in 3 months.

--- a/specs/issue-287-lcp-investigation/research.md
+++ b/specs/issue-287-lcp-investigation/research.md
@@ -1,0 +1,84 @@
+# Research — Issue #287: Desktop LCP Investigation
+
+**Date:** 2026-04-26
+**Window:** Last 7 days (post-#284 cloaking-fix merge)
+**Source:** PostHog `$web_vitals` events, project 275753
+
+## TL;DR — Verdict: Bot Artifact (Path A)
+
+The 22.4s desktop LCP is **measurement contamination from a single headless-Chrome bot**, not a real user-experience issue. Real users are fine. No code performance fix needed; only a measurement-filter fix.
+
+| Cohort | Samples | Share | Avg LCP | p50 LCP | p95 LCP |
+|---|---|---|---|---|---|
+| **Suspect bot** (Chrome 145, screen 800x600, viewport 1920) | 154 | 81.5% | 20.88s | 21.70s | 45.95s |
+| **Real users** (everything else, desktop) | 35 | 18.5% | 2.28s | **1.99s** | 5.75s |
+
+Real-user p50 of **1.99s is well under Google's "good" threshold of 2.5s**. Mobile remains fine at p50 ~1.0s.
+
+## Bot Fingerprint (Q5 + Q7)
+
+154 of 189 desktop LCP samples share an identical signature:
+- `User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36`
+- `$screen_width: 800`, `$screen_height: 600`, `$viewport_width: 1920` — impossible combo on a real Windows desktop (real Win10 desktops are 1920x1080+ screen, viewport ≤ screen)
+- 100% of samples come from `$referring_domain: www.google.com`
+- All hit `/never-hungover/*` review/comparison pages
+- Chrome 145 is six months stale (current Chrome is 147); zero plausible real-user concentration on 145
+
+This is consistent with **Google's "Site preview" / SERP rich-result rendering bot** — a headless Chrome that fetches your page from Google's servers, throttles CPU/network, and reports inflated Web Vitals via the standard PostHog SDK. The bot is *not* in PostHog's default bot-blocklist because it presents as a regular browser.
+
+## LCP Distribution (Q4) — Bimodal
+
+Histogram of desktop LCP (n=189) shows a clean bimodal split:
+- **0-5s cluster:** 67 samples (35.5%) — real users
+- **5-10s gap:** 17 samples (9%) — transition zone
+- **10-60s long tail:** 105 samples (55.5%) — bot
+
+A unimodal real-user perf problem produces a single peak with a tail. A bimodal distribution like this is a near-certain mixed-population artifact.
+
+## Per-Page LCP (Q2)
+
+The "worst pages" (avg LCP 25-43s) are all `/never-hungover/*` comparison/review posts — exactly the surfaces Google rich-results / Site Preview crawls aggressively. Information pages (e.g. `/dhm-dosage-guide-2025`) show normal real-user LCP (~2-4s). The pattern matches "bot loads commercial pages for SERP previews," not "comparison pages have a perf bug."
+
+## Referrer Breakdown (Q3)
+
+| Referrer | Samples | Avg LCP |
+|---|---|---|
+| www.google.com | 179 | 18.21s |
+| `$direct` | 7 | 4.24s |
+| www.dhmguide.com (internal) | 2 | 2.34s |
+| duckduckgo.com | 1 | 0.80s |
+
+The 179 Google-referred desktop samples include all 154 bot samples — confirms bot enters via Google referral header (preview crawler convention).
+
+## Browser Breakdown (Q1)
+
+| Browser | Samples | p50 LCP | p95 LCP |
+|---|---|---|---|
+| Chrome | 180 | 17.78s | 43.14s |
+| Safari | 5 | 0.71s | 1.44s |
+| Edge | 3 | 1.97s | 2.64s |
+| Firefox | 1 | 2.92s | 2.92s |
+
+Non-Chrome desktop browsers (n=9) all average <3s — strong evidence that Chrome the *browser* isn't slow on our site; rather, *one specific stale Chrome version + bot fingerprint* is dragging the average.
+
+## Did the #284 Cloaking Fix Help?
+
+The data in this report is from the 7 days following #284 merge. Real-user p50 desktop LCP is now 1.99s, well within the "good" range. We have no clean pre-#284 dataset isolated from bots to A/B against, but #284 is consistent with shipping full-content prerendered HTML (faster largest-paint candidate), and real-user LCP looks healthy. No regression to chase.
+
+## Decision
+
+**Path A — bot artifact.** No code-performance fix.
+
+Action: ship a measurement-helper subcommand `./scripts/posthog-query.sh lcp-real` that filters out the bot fingerprint so future LCP checks return real-user numbers. Document the bot signature so anyone running future audits doesn't get fooled the same way.
+
+## Queries Used (reproducible)
+
+All queries hit `POST https://us.posthog.com/api/projects/275753/query` with HogQL:
+
+- **Q1** Browser breakdown: `SELECT properties.$browser, count(), avg/quantile(properties.$web_vitals_LCP_value) FROM events WHERE event='$web_vitals' AND properties.$device_type='Desktop' AND timestamp > now() - INTERVAL 7 DAY GROUP BY browser`
+- **Q2** Per-page: same with `GROUP BY properties.$pathname ORDER BY avg DESC LIMIT 10`
+- **Q3** Referrer: same with `GROUP BY properties.$referring_domain`
+- **Q4** Histogram: `SELECT floor(properties.$web_vitals_LCP_value / 1000) AS bucket, count() GROUP BY bucket`
+- **Q5** UA grouping: `GROUP BY properties.$raw_user_agent ORDER BY count DESC`
+- **Q6** Cohort split: `CASE WHEN $raw_user_agent LIKE '%Chrome/145.0.0.0%' THEN 'bot' ELSE 'real' END`
+- **Q7** Screen-size uniformity: `GROUP BY $screen_width, $screen_height, $viewport_width` — confirmed all 154 bot samples are 800x600/viewport 1920

--- a/specs/issue-287-lcp-investigation/tasks.md
+++ b/specs/issue-287-lcp-investigation/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — Issue #287
+
+## T1: Add `lcp-real` subcommand to `scripts/posthog-query.sh`
+- Insert new `lcp-real)` case (next to `dead-clicks-real)` for tonal consistency).
+- Embed HogQL query from `design.md`.
+- Format output as a small table (cohort / samples / avg / p50 / p75 / p95 in seconds).
+- Add `echo "  lcp-real          - Desktop LCP split between real users and bot..."` to the `*)` help block.
+- Add a short comment above the case explaining the bot fingerprint and pointing to `specs/issue-287-lcp-investigation/research.md`.
+
+## T2: Verify
+- Run `./scripts/posthog-query.sh lcp-real` locally with `POSTHOG_PERSONAL_API_KEY` set.
+- Confirm real-user p50 < 2500ms.
+- Confirm `./scripts/posthog-query.sh` (no args) lists the new command.
+
+## T3: Commit + PR + merge
+- Commit on `spec/issue-287-lcp-investigation`.
+- Title: `feat: filter bot traffic from LCP measurement (#287)`.
+- Body: `Closes #287. Refs #283.`
+- Squash-merge with `--admin`.


### PR DESCRIPTION
## Summary
Desktop LCP showing 22.4s avg in PostHog isn't a real perf regression — it's a single headless-Chrome bot (Chrome/145, screen 800x600, viewport 1920, www.google.com referrer) producing 81.5% of desktop samples. Real-user desktop p50 is **1.99s**, well under Google's 2.5s "good" threshold.

This PR adds a `./scripts/posthog-query.sh lcp-real` subcommand that splits real-user vs bot LCP so future audits return real numbers without manual filtering.

## Evidence
- 154 of 189 desktop `$web_vitals` samples share an identical UA + impossible 800×600 screen / 1920 viewport combo
- 100% of bot samples come from `www.google.com` referrer; concentrated on `/never-hungover/*` review pages
- Bimodal LCP distribution: 0–5s real-user cluster vs 10–60s bot tail
- Non-Chrome desktop browsers (Safari/Edge/Firefox, n=9) all p50 < 3s

Full investigation in `specs/issue-287-lcp-investigation/research.md`.

## Test plan
- [x] `./scripts/posthog-query.sh lcp-real` returns table with real_user p50 < 2.5s
- [x] `./scripts/posthog-query.sh` (no args) help lists the new command
- [x] Bash syntax check passes

Closes #287. Refs #283.