### PR TITLE
feat: PostHog dashboard - 10 measurement tiles for traffic-growth plan (#308)

### DIFF
--- a/scripts/posthog-create-dashboard.sh
+++ b/scripts/posthog-create-dashboard.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Creates the "Traffic Growth — 10 Tile Master" dashboard in PostHog from
+# scripts/posthog-dashboard-config.json. Idempotent in the sense that re-running
+# it will create a NEW dashboard each time — there's no "find or create" because
+# PostHog allows duplicate names; check the URL it prints.
+#
+# Usage:
+#   ./scripts/posthog-create-dashboard.sh                   # uses default config
+#   ./scripts/posthog-create-dashboard.sh path/to/cfg.json  # custom config
+#
+# Refs issue #308.
+
+set -euo pipefail
+
+API_KEY="${POSTHOG_PERSONAL_API_KEY:?Set POSTHOG_PERSONAL_API_KEY in your environment (~/.zshrc)}"
+PROJECT_ID="${POSTHOG_PROJECT_ID:-275753}"
+BASE="https://us.posthog.com/api/projects/${PROJECT_ID}"
+CONFIG="${1:-$(dirname "$0")/posthog-dashboard-config.json}"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "Config file not found: $CONFIG" >&2
+  exit 1
+fi
+
+# Hand off to python — much cleaner than bash + jq for this nested API dance.
+API_KEY="$API_KEY" BASE="$BASE" CONFIG="$CONFIG" PROJECT_ID="$PROJECT_ID" python3 - <<'PYEOF'
+import json, os, sys, urllib.request, urllib.error
+
+api_key = os.environ["API_KEY"]
+base = os.environ["BASE"]
+project_id = os.environ["PROJECT_ID"]
+cfg_path = os.environ["CONFIG"]
+
+with open(cfg_path) as f:
+    cfg = json.load(f)
+
+def post(url, body):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code} on POST {url}\n{body}", file=sys.stderr)
+        raise
+
+# 1. Create dashboard
+dash = post(f"{base}/dashboards/", {
+    "name": cfg["name"],
+    "description": cfg.get("description", ""),
+})
+dash_id = dash["id"]
+print(f"Created dashboard id={dash_id}")
+
+# 2. Create insights, attaching each to the dashboard
+for i, tile in enumerate(cfg["tiles"], 1):
+    insight = post(f"{base}/insights/", {
+        "name": tile["name"],
+        "query": tile["query"],
+        "dashboards": [dash_id],
+        "saved": True,
+    })
+    print(f"  [{i:>2}/{len(cfg['tiles'])}] insight id={insight['id']} — {tile['name']}")
+
+print()
+print(f"Dashboard URL: https://us.posthog.com/project/{project_id}/dashboard/{dash_id}")
+PYEOF

--- a/scripts/posthog-dashboard-config.json
+++ b/scripts/posthog-dashboard-config.json
@@ -1,0 +1,116 @@
+{
+  "name": "Traffic Growth \u2014 10 Tile Master",
+  "description": "Measurement infrastructure for the 6-month traffic-growth plan (#283). Built per issue #308. Every tile is also runnable as a CLI subcommand via scripts/posthog-query.sh \u2014 same SQL, single source of truth.",
+  "tiles": [
+    {
+      "name": "Channel mix (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT CASE WHEN properties.$referrer LIKE '%google.%' THEN 'google' WHEN properties.$referrer LIKE '%bing.%' THEN 'bing' WHEN properties.$referrer LIKE '%duckduckgo%' THEN 'duckduckgo' WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot' WHEN properties.$referrer LIKE '%facebook%' OR properties.$referrer LIKE '%instagram%' OR properties.$referrer LIKE '%t.co%' OR properties.$referrer LIKE '%reddit%' THEN 'social' WHEN properties.$referrer = '$direct' OR properties.$referrer IS NULL OR properties.$referrer = '' THEN 'direct' ELSE 'other' END AS channel, count() AS pageviews, round(100.0 * count() / sum(count()) OVER (), 2) AS pct FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY channel ORDER BY pageviews DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Daily pageviews (90d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT toDate(timestamp) AS day, count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 90 DAY GROUP BY day ORDER BY day DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Affiliate clicks by channel (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT CASE WHEN properties.$referrer LIKE '%google.%' THEN 'google' WHEN properties.$referrer LIKE '%bing.%' THEN 'bing' WHEN properties.$referrer LIKE '%duckduckgo%' THEN 'duckduckgo' WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot' WHEN properties.$referrer LIKE '%facebook%' OR properties.$referrer LIKE '%instagram%' OR properties.$referrer LIKE '%t.co%' OR properties.$referrer LIKE '%reddit%' THEN 'social' WHEN properties.$referrer = '$direct' OR properties.$referrer IS NULL OR properties.$referrer = '' THEN 'direct' ELSE 'other' END AS channel, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY channel ORDER BY clicks DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "AI-search referrers (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT CASE WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot' END AS engine, count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY AND (properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' OR properties.$referrer LIKE '%perplexity%' OR properties.$referrer LIKE '%claude.ai%' OR properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' OR properties.$referrer LIKE '%copilot.microsoft%') GROUP BY engine ORDER BY pageviews DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Top 20 pages by pageviews (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT properties.$pathname AS path, count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path ORDER BY pageviews DESC LIMIT 20"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Top 20 pages by affiliate CTR (30d, min 50 PV)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT pv.path AS path, pv.pageviews AS pageviews, coalesce(aff.clicks, 0) AS clicks, round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS ctr_pct FROM (SELECT properties.$pathname AS path, count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path) pv LEFT JOIN (SELECT properties.$pathname AS path, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path) aff ON aff.path = pv.path WHERE pv.pageviews >= 50 ORDER BY ctr_pct DESC LIMIT 20"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Engagement watchdog: time_on_page_milestone (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT toDate(timestamp) AS day, count() AS milestones FROM events WHERE event = 'time_on_page_milestone' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Exception watchdog: $exception (30d)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT toDate(timestamp) AS day, count() AS exceptions FROM events WHERE event = '$exception' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Newsletter signups (30d, expect 0 pre-#285)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT toDate(timestamp) AS day, count() AS signups FROM events WHERE event = 'newsletter_subscribe_succeeded' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC"
+        },
+        "full": true
+      }
+    },
+    {
+      "name": "Mobile vs desktop CR per page (30d, top 20 by PV)",
+      "query": {
+        "kind": "DataTableNode",
+        "source": {
+          "kind": "HogQLQuery",
+          "query": "SELECT pv.path AS path, pv.device AS device, pv.pageviews AS pageviews, coalesce(aff.clicks, 0) AS clicks, round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS cr_pct FROM (SELECT properties.$pathname AS path, properties.$device_type AS device, count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path, device) pv LEFT JOIN (SELECT properties.$pathname AS path, properties.$device_type AS device, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path, device) aff ON aff.path = pv.path AND aff.device = pv.device WHERE pv.pageviews >= 50 ORDER BY pv.pageviews DESC LIMIT 20"
+        },
+        "full": true
+      }
+    }
+  ]
+}

--- a/scripts/posthog-query.sh
+++ b/scripts/posthog-query.sh
@@ -5,6 +5,29 @@
 API_KEY="${POSTHOG_PERSONAL_API_KEY:?Set POSTHOG_PERSONAL_API_KEY in your environment (~/.zshrc) — see docs/posthog-analysis-2026-04-25/r10-hygiene.md}"
 BASE_URL="https://us.posthog.com/api/projects/@current"
 
+# hogql_table SQL HEADERS_CSV
+# Runs an arbitrary HogQL string and prints CSV (header + rows) to stdout.
+# Used by the 10 traffic-growth dashboard subcommands below — single source of
+# truth for the SQL that also powers scripts/posthog-dashboard-config.json.
+hogql_table() {
+  local sql="$1"
+  local headers="$2"
+  local payload
+  payload=$(python3 -c 'import json,sys; print(json.dumps({"query":{"kind":"HogQLQuery","query":sys.argv[1]}}))' "$sql")
+  curl -s -X POST "$BASE_URL/query" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    | HEADERS="$headers" python3 -c "
+import json, os, sys
+d = json.load(sys.stdin)
+hdr = os.environ.get('HEADERS','').split(',') if os.environ.get('HEADERS') else d.get('columns', [])
+if hdr:
+    print(','.join(hdr))
+for r in d.get('results', []):
+    print(','.join('' if c is None else str(c) for c in r))"
+}
+
 case "$1" in
   events)
     echo "=== Event Counts (Last 7 Days) ==="
@@ -97,6 +120,61 @@ print()
 print('Note: Google\\'s \"good\" LCP threshold is 2.5s. Real-user p50 is the headline number.')"
     ;;
 
+  # ─── Traffic-growth dashboard tiles (issue #308) ─────────────────────────
+  # Each subcommand below runs the canonical HogQL for one of the 10
+  # dashboard tiles. The same SQL is mirrored into
+  # scripts/posthog-dashboard-config.json — keep them in sync.
+
+  channel-mix)
+    echo "=== Channel Mix (last 30d) ==="
+    hogql_table "SELECT CASE WHEN properties.\$referrer LIKE '%google.%' THEN 'google' WHEN properties.\$referrer LIKE '%bing.%' THEN 'bing' WHEN properties.\$referrer LIKE '%duckduckgo%' THEN 'duckduckgo' WHEN properties.\$referrer LIKE '%chatgpt%' OR properties.\$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.\$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.\$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.\$referrer LIKE '%gemini.google%' OR properties.\$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.\$referrer LIKE '%copilot.microsoft%' THEN 'copilot' WHEN properties.\$referrer LIKE '%facebook%' OR properties.\$referrer LIKE '%instagram%' OR properties.\$referrer LIKE '%t.co%' OR properties.\$referrer LIKE '%reddit%' THEN 'social' WHEN properties.\$referrer = '\$direct' OR properties.\$referrer IS NULL OR properties.\$referrer = '' THEN 'direct' ELSE 'other' END AS channel, count() AS pageviews, round(100.0 * count() / sum(count()) OVER (), 2) AS pct FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY channel ORDER BY pageviews DESC" "channel,pageviews,pct"
+    ;;
+
+  daily-pv)
+    echo "=== Daily Pageviews (last 90d) ==="
+    hogql_table "SELECT toDate(timestamp) AS day, count() AS pageviews FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 90 DAY GROUP BY day ORDER BY day DESC" "day,pageviews"
+    ;;
+
+  affiliate-by-channel)
+    echo "=== Affiliate Clicks by Channel (last 30d) ==="
+    hogql_table "SELECT CASE WHEN properties.\$referrer LIKE '%google.%' THEN 'google' WHEN properties.\$referrer LIKE '%bing.%' THEN 'bing' WHEN properties.\$referrer LIKE '%duckduckgo%' THEN 'duckduckgo' WHEN properties.\$referrer LIKE '%chatgpt%' OR properties.\$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.\$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.\$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.\$referrer LIKE '%gemini.google%' OR properties.\$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.\$referrer LIKE '%copilot.microsoft%' THEN 'copilot' WHEN properties.\$referrer LIKE '%facebook%' OR properties.\$referrer LIKE '%instagram%' OR properties.\$referrer LIKE '%t.co%' OR properties.\$referrer LIKE '%reddit%' THEN 'social' WHEN properties.\$referrer = '\$direct' OR properties.\$referrer IS NULL OR properties.\$referrer = '' THEN 'direct' ELSE 'other' END AS channel, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY channel ORDER BY clicks DESC" "channel,clicks"
+    ;;
+
+  ai-search)
+    echo "=== AI-Search Referrers (last 30d) ==="
+    hogql_table "SELECT CASE WHEN properties.\$referrer LIKE '%chatgpt%' OR properties.\$referrer LIKE '%openai%' THEN 'chatgpt' WHEN properties.\$referrer LIKE '%perplexity%' THEN 'perplexity' WHEN properties.\$referrer LIKE '%claude.ai%' THEN 'claude' WHEN properties.\$referrer LIKE '%gemini.google%' OR properties.\$referrer LIKE '%bard.google%' THEN 'gemini' WHEN properties.\$referrer LIKE '%copilot.microsoft%' THEN 'copilot' END AS engine, count() AS pageviews FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 30 DAY AND (properties.\$referrer LIKE '%chatgpt%' OR properties.\$referrer LIKE '%openai%' OR properties.\$referrer LIKE '%perplexity%' OR properties.\$referrer LIKE '%claude.ai%' OR properties.\$referrer LIKE '%gemini.google%' OR properties.\$referrer LIKE '%bard.google%' OR properties.\$referrer LIKE '%copilot.microsoft%') GROUP BY engine ORDER BY pageviews DESC" "engine,pageviews"
+    ;;
+
+  top-pv)
+    echo "=== Top 20 Pages by Pageviews (last 30d) ==="
+    hogql_table "SELECT properties.\$pathname AS path, count() AS pageviews FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path ORDER BY pageviews DESC LIMIT 20" "path,pageviews"
+    ;;
+
+  top-ctr)
+    echo "=== Top 20 Pages by Affiliate CTR (last 30d, min 50 PV) ==="
+    hogql_table "SELECT pv.path AS path, pv.pageviews AS pageviews, coalesce(aff.clicks, 0) AS clicks, round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS ctr_pct FROM (SELECT properties.\$pathname AS path, count() AS pageviews FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path) pv LEFT JOIN (SELECT properties.\$pathname AS path, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path) aff ON aff.path = pv.path WHERE pv.pageviews >= 50 ORDER BY ctr_pct DESC LIMIT 20" "path,pageviews,clicks,ctr_pct"
+    ;;
+
+  engagement-watchdog)
+    echo "=== time_on_page_milestone Daily Volume (last 30d) ==="
+    hogql_table "SELECT toDate(timestamp) AS day, count() AS milestones FROM events WHERE event = 'time_on_page_milestone' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC" "day,milestones"
+    ;;
+
+  exception-watchdog)
+    echo "=== \$exception Daily Count (last 30d) ==="
+    hogql_table "SELECT toDate(timestamp) AS day, count() AS exceptions FROM events WHERE event = '\$exception' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC" "day,exceptions"
+    ;;
+
+  newsletter-signups)
+    echo "=== newsletter_subscribe_succeeded (last 30d; expect 0 until #285 ships) ==="
+    hogql_table "SELECT toDate(timestamp) AS day, count() AS signups FROM events WHERE event = 'newsletter_subscribe_succeeded' AND timestamp > now() - INTERVAL 30 DAY GROUP BY day ORDER BY day DESC" "day,signups"
+    ;;
+
+  device-cr)
+    echo "=== Mobile vs Desktop CR per Page (last 30d, top 20 by PV) ==="
+    hogql_table "SELECT pv.path AS path, pv.device AS device, pv.pageviews AS pageviews, coalesce(aff.clicks, 0) AS clicks, round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS cr_pct FROM (SELECT properties.\$pathname AS path, properties.\$device_type AS device, count() AS pageviews FROM events WHERE event = '\$pageview' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path, device) pv LEFT JOIN (SELECT properties.\$pathname AS path, properties.\$device_type AS device, count() AS clicks FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY GROUP BY path, device) aff ON aff.path = pv.path AND aff.device = pv.device WHERE pv.pageviews >= 50 ORDER BY pv.pageviews DESC LIMIT 20" "path,device,pageviews,clicks,cr_pct"
+    ;;
+
   *)
     echo "PostHog Query Helper"
     echo "Usage: $0 [command]"
@@ -110,5 +188,17 @@ print('Note: Google\\'s \"good\" LCP threshold is 2.5s. Real-user p50 is the hea
     echo "  dead-clicks-raw   - Total \$dead_click count (unfiltered, includes affiliate false-positives)"
     echo "  dead-clicks-real  - \$dead_click count filtered to exclude Amazon/Fuller affiliate false-positives"
     echo "  lcp-real          - Desktop LCP split between real users and the SERP-preview bot (filters Chrome/145 + 800x600 screen)"
+    echo ""
+    echo "Traffic-growth dashboard tiles (issue #308):"
+    echo "  channel-mix          - Channel mix % over last 30d (google/bing/AI/social/direct)"
+    echo "  daily-pv             - Daily pageview trend, last 90d"
+    echo "  affiliate-by-channel - Affiliate clicks grouped by channel, last 30d"
+    echo "  ai-search            - AI-search referrer pageviews by engine, last 30d"
+    echo "  top-pv               - Top 20 pages by pageviews, last 30d"
+    echo "  top-ctr              - Top 20 pages by affiliate CTR (min 50 PV), last 30d"
+    echo "  engagement-watchdog  - time_on_page_milestone daily volume, last 30d"
+    echo "  exception-watchdog   - \$exception daily count, last 30d"
+    echo "  newsletter-signups   - Newsletter signup count, last 30d"
+    echo "  device-cr            - Mobile vs desktop CR per page, last 30d"
     ;;
 esac

--- a/specs/issue-308-posthog-dashboard/design.md
+++ b/specs/issue-308-posthog-dashboard/design.md
@@ -1,0 +1,204 @@
+# Design — Issue #308 PostHog Dashboard
+
+## File layout
+
+```
+scripts/
+  posthog-query.sh                 (MODIFIED — add 10 subcommands)
+  posthog-dashboard-config.json    (NEW — 10-insight dashboard spec)
+  posthog-create-dashboard.sh      (NEW — apply config via API)
+```
+
+## Channel-classification SQL (shared)
+
+Reused inline in 3 of the 10 queries (channel-mix, affiliate-by-channel, ai-search). Kept inline rather than as a UDF — HogQL doesn't support persistent UDFs and inlining keeps each query copy-paste-runnable in PostHog UI.
+
+## The 10 HogQL queries
+
+### 1. channel-mix
+```sql
+SELECT
+  CASE
+    WHEN properties.$referrer LIKE '%google.%' THEN 'google'
+    WHEN properties.$referrer LIKE '%bing.%' THEN 'bing'
+    WHEN properties.$referrer LIKE '%duckduckgo%' THEN 'duckduckgo'
+    WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt'
+    WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity'
+    WHEN properties.$referrer LIKE '%claude.ai%' THEN 'claude'
+    WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini'
+    WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot'
+    WHEN properties.$referrer LIKE '%facebook%' OR properties.$referrer LIKE '%instagram%' OR properties.$referrer LIKE '%t.co%' OR properties.$referrer LIKE '%reddit%' THEN 'social'
+    WHEN properties.$referrer = '$direct' OR properties.$referrer IS NULL OR properties.$referrer = '' THEN 'direct'
+    ELSE 'other'
+  END AS channel,
+  count() AS pageviews,
+  round(100.0 * count() / sum(count()) OVER (), 2) AS pct
+FROM events
+WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY channel
+ORDER BY pageviews DESC
+```
+
+### 2. daily-pv
+```sql
+SELECT toDate(timestamp) AS day, count() AS pageviews
+FROM events
+WHERE event = '$pageview' AND timestamp > now() - INTERVAL 90 DAY
+GROUP BY day ORDER BY day DESC
+```
+
+### 3. affiliate-by-channel
+Same channel CASE applied to `affiliate_link_click` events.
+
+### 4. ai-search
+```sql
+SELECT
+  CASE
+    WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt'
+    WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity'
+    WHEN properties.$referrer LIKE '%claude.ai%' THEN 'claude'
+    WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini'
+    WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot'
+  END AS engine,
+  count() AS pageviews
+FROM events
+WHERE event = '$pageview'
+  AND timestamp > now() - INTERVAL 30 DAY
+  AND (properties.$referrer LIKE '%chatgpt%'
+    OR properties.$referrer LIKE '%openai%'
+    OR properties.$referrer LIKE '%perplexity%'
+    OR properties.$referrer LIKE '%claude.ai%'
+    OR properties.$referrer LIKE '%gemini.google%'
+    OR properties.$referrer LIKE '%bard.google%'
+    OR properties.$referrer LIKE '%copilot.microsoft%')
+GROUP BY engine ORDER BY pageviews DESC
+```
+
+### 5. top-pv
+```sql
+SELECT properties.$pathname AS path, count() AS pageviews
+FROM events
+WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY path ORDER BY pageviews DESC LIMIT 20
+```
+
+### 6. top-ctr
+```sql
+SELECT
+  pv.path AS path,
+  pv.pageviews,
+  coalesce(aff.clicks, 0) AS clicks,
+  round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS ctr_pct
+FROM (
+  SELECT properties.$pathname AS path, count() AS pageviews
+  FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY
+  GROUP BY path
+) pv
+LEFT JOIN (
+  SELECT properties.$pathname AS path, count() AS clicks
+  FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY
+  GROUP BY path
+) aff ON aff.path = pv.path
+WHERE pv.pageviews >= 50
+ORDER BY ctr_pct DESC LIMIT 20
+```
+
+### 7. engagement-watchdog
+```sql
+SELECT toDate(timestamp) AS day, count() AS milestones
+FROM events
+WHERE event = 'time_on_page_milestone' AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day DESC
+```
+
+### 8. exception-watchdog
+```sql
+SELECT toDate(timestamp) AS day, count() AS exceptions
+FROM events
+WHERE event = '$exception' AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day DESC
+```
+
+### 9. newsletter-signups
+```sql
+SELECT toDate(timestamp) AS day, count() AS signups
+FROM events
+WHERE event = 'newsletter_subscribe_succeeded' AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day DESC
+```
+
+### 10. device-cr
+```sql
+SELECT
+  pv.path AS path,
+  pv.device AS device,
+  pv.pageviews,
+  coalesce(aff.clicks, 0) AS clicks,
+  round(100.0 * coalesce(aff.clicks, 0) / pv.pageviews, 2) AS cr_pct
+FROM (
+  SELECT properties.$pathname AS path, properties.$device_type AS device, count() AS pageviews
+  FROM events WHERE event = '$pageview' AND timestamp > now() - INTERVAL 30 DAY
+  GROUP BY path, device
+) pv
+LEFT JOIN (
+  SELECT properties.$pathname AS path, properties.$device_type AS device, count() AS clicks
+  FROM events WHERE event = 'affiliate_link_click' AND timestamp > now() - INTERVAL 30 DAY
+  GROUP BY path, device
+) aff ON aff.path = pv.path AND aff.device = pv.device
+WHERE pv.pageviews >= 50
+ORDER BY pv.pageviews DESC LIMIT 20
+```
+
+## Subcommand implementation pattern
+
+Inside `posthog-query.sh`, write a helper that takes a HogQL string and pipes JSON results to a python printer. Each subcommand:
+
+```bash
+hogql_table() {
+  local sql="$1"; shift
+  local headers="$*"
+  local payload
+  payload=$(python3 -c 'import json,sys; print(json.dumps({"query":{"kind":"HogQLQuery","query":sys.argv[1]}}))' "$sql")
+  curl -s -X POST "$BASE_URL/query" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+hdr='$headers'.split(',') if '$headers' else d.get('columns',[])
+print(','.join(hdr))
+for r in d.get('results',[]):
+    print(','.join(str(c) for c in r))"
+}
+```
+
+Each subcommand calls `hogql_table "<SQL>" "col1,col2,..."`. Avoids the `'"'"'` escaping mess by passing the SQL through python's json encoder.
+
+## Dashboard JSON shape
+
+```json
+{
+  "name": "Traffic Growth — 10 Tile Master",
+  "description": "...",
+  "tiles": [
+    {
+      "name": "Channel mix (30d)",
+      "query": { "kind": "DataTableNode", "source": { "kind": "HogQLQuery", "query": "..." } }
+    },
+    ...
+  ]
+}
+```
+
+## Dashboard create script
+
+Pseudocode:
+```
+1. POST /dashboards/ {name, description} → dashboard_id
+2. For each tile in config:
+   POST /insights/ {name, query, dashboards: [dashboard_id], saved: true}
+3. Print https://us.posthog.com/project/275753/dashboard/<id>
+```
+
+Implementation in bash + python3 inline (consistent with existing scripts).

--- a/specs/issue-308-posthog-dashboard/plan.md
+++ b/specs/issue-308-posthog-dashboard/plan.md
@@ -1,0 +1,34 @@
+# [Phase 1] Build PostHog dashboard — 10 tiles per master plan
+
+Refs #283. **Promoted from Phase 5 → Phase 1** per consolidation audit: measurement infrastructure must exist BEFORE Phases 1-4 ship so we can capture pre-deploy baselines and track per-PR impact.
+
+## Why this is Phase 1
+
+Without this dashboard built first:
+- Per-PR HogQL gates (per `00-MASTER-PLAN.md` §Measurement Infrastructure) are ad-hoc
+- The Phase 1 cloaking fix (#284) lift cannot be measured against a documented baseline
+- AI-search referrer growth (the keystone metric for the whole 6-month plan) has no monitoring tile
+
+## 10 tiles (~3-4 hrs)
+
+1. Channel mix (last 30d, % per channel) — flag if Google moves >5pp WoW
+2. Daily PV trend (last 90d)
+3. Affiliate clicks per channel
+4. AI-search referrer count (chatgpt/perplexity/claude/gemini/copilot)
+5. Top 20 pages by PV
+6. Top 20 pages by affiliate CTR
+7. `time_on_page_milestone` daily volume (regression watchdog)
+8. `$exception` count (regression watchdog)
+9. Newsletter signup count (zero today; >0 after #285 ships)
+10. Mobile vs desktop CR per page
+
+Full HogQL queries provided in master plan §Measurement Infrastructure.
+
+## Suggested ship order
+
+Build the dashboard FIRST (before #284 cloaking fix lands) so the cloaking-fix impact can be measured cleanly. Or ship in parallel: dashboard work is independent of code changes.
+
+## Source
+`docs/traffic-growth-2026-04-26/00-MASTER-PLAN.md`, `10-diversification.md`, `issue-consolidation-audit.md` Gap #7.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-308-posthog-dashboard/requirements.md
+++ b/specs/issue-308-posthog-dashboard/requirements.md
@@ -1,0 +1,38 @@
+# Requirements — Issue #308 PostHog Dashboard
+
+## Functional
+
+1. **10 HogQL subcommands** added to `scripts/posthog-query.sh`:
+   - `channel-mix` — last 30d, channel & pageview count, percentage
+   - `daily-pv` — daily pageview count, last 90d
+   - `affiliate-by-channel` — affiliate_link_click count grouped by synthesized channel
+   - `ai-search` — pageview count grouped by AI-search referrer engine
+   - `top-pv` — top 20 pages by pageview count, last 30d
+   - `top-ctr` — top 20 pages by affiliate_link_click / pageview ratio (last 30d)
+   - `engagement-watchdog` — time_on_page_milestone daily count, last 30d
+   - `exception-watchdog` — $exception daily count, last 30d
+   - `newsletter-signups` — newsletter_subscribe_succeeded count, last 30d
+   - `device-cr` — mobile vs desktop conversion rate (affiliate clicks / pageviews) per page, last 30d, top 20
+
+2. **Dashboard config JSON** at `scripts/posthog-dashboard-config.json`:
+   - Dashboard name: "Traffic Growth — 10 Tile Master"
+   - 10 insights, one per subcommand, using `DataTableNode` + identical HogQL strings.
+
+3. **Dashboard creation script** at `scripts/posthog-create-dashboard.sh`:
+   - Reads the config JSON.
+   - POSTs dashboard, then POSTs each insight (attached to dashboard).
+   - Prints final dashboard URL.
+
+## Non-functional
+
+- Auth via `POSTHOG_PERSONAL_API_KEY` (existing pattern, no new env vars).
+- Project id `275753` (matches `posthog-baseline.sh`).
+- Subcommand output: CSV-friendly text to stdout for diff vs baseline.
+- Each subcommand's HogQL must match the corresponding dashboard insight's HogQL exactly (single source of truth — copy-paste safe).
+- Help text (`./scripts/posthog-query.sh` no args) lists all new commands.
+
+## Out of scope
+
+- Modifying `posthog-baseline.sh` (existing scalars cover the watchdog tiles already).
+- Live dashboard creation — script can be run by user; we attempt it but do not block on success.
+- Adding tracking for new events (e.g., wiring newsletter signup itself — that's #285).

--- a/specs/issue-308-posthog-dashboard/research.md
+++ b/specs/issue-308-posthog-dashboard/research.md
@@ -1,0 +1,72 @@
+# Research — Issue #308 PostHog Dashboard (10 tiles)
+
+## Existing patterns
+
+### `scripts/posthog-query.sh`
+- Bash CLI dispatched via `case "$1"`.
+- Auth: `POSTHOG_PERSONAL_API_KEY` env var (required, fail if missing).
+- BASE_URL: `https://us.posthog.com/api/projects/@current` (resolves project from key).
+- Two query styles in use:
+  - `EventsQuery` (high-level)
+  - `HogQLQuery` (raw SQL — preferred for this work since master plan provides HogQL)
+- Output: piped to `python3 -c` for compact CSV/table formatting.
+- Embedded SQL uses awkward `'"'"'` escaping. Cleaner option for new subcommands: read query from a heredoc into a variable, jq-encode into JSON.
+
+### `scripts/posthog-baseline.sh`
+- Same auth pattern. Different base: `/api/projects/275753/query` (hardcoded project id).
+- Wraps `curl + python3` into a `hog()` shell function returning the first cell as a scalar.
+- Writes CSV to `specs/issue-268-implementation/baseline-pre-merge.csv`.
+- This is the per-PR baseline harness referenced in issue #308's promotion rationale.
+
+### Event taxonomy (from `src/lib/posthog.js`)
+- `$pageview` — every page (with `$pathname`, `$current_url`, `$referrer`).
+- `affiliate_link_click` — Amazon clicks (props: `product_name`, `placement`, `link_position`).
+- `scroll_depth_milestone` — props: `depth_percentage`, `page_path`, `device_type`.
+- `time_on_page_milestone` — engagement watchdog.
+- `$exception` — auto from PostHog SDK.
+- `newsletter_subscribe_succeeded` — wired in `DosageCalculatorEnhanced.jsx:747` (zero events today; will fire after #285 ships).
+- Person props include `initial_referrer`, `initial_utm_source/medium/campaign`.
+
+## PostHog dashboard API
+
+PostHog supports programmatic dashboard creation:
+- `POST /api/projects/<project_id>/dashboards/` — create dashboard (returns dashboard id).
+- `POST /api/projects/<project_id>/insights/` — create insight; pass `dashboards: [<id>]` to attach.
+- Insight payload uses `query` field (same shape as `/query` endpoint). Query kinds: `HogQLQuery`, `TrendsQuery`, `EventsQuery`.
+
+For HogQL-based tiles, `DataTableNode` wraps a `HogQLQuery` so PostHog renders the table view. `InsightVizNode` wraps `TrendsQuery` for line charts. We can stick with `DataTableNode` + HogQL for all 10 tiles — keeps source-of-truth identical to the CLI.
+
+Project id `275753` already used in `posthog-baseline.sh` — reuse.
+
+## Channel definition (HogQL)
+
+PostHog doesn't auto-derive a "channel" from `$referrer` like GA4. We synthesize:
+```sql
+CASE
+  WHEN properties.$referrer LIKE '%google%' THEN 'google'
+  WHEN properties.$referrer LIKE '%bing%' THEN 'bing'
+  WHEN properties.$referrer LIKE '%duckduckgo%' THEN 'duckduckgo'
+  WHEN properties.$referrer LIKE '%chatgpt%' OR properties.$referrer LIKE '%openai%' THEN 'chatgpt'
+  WHEN properties.$referrer LIKE '%perplexity%' THEN 'perplexity'
+  WHEN properties.$referrer LIKE '%claude.ai%' OR properties.$referrer LIKE '%anthropic%' THEN 'claude'
+  WHEN properties.$referrer LIKE '%gemini.google%' OR properties.$referrer LIKE '%bard.google%' THEN 'gemini'
+  WHEN properties.$referrer LIKE '%copilot.microsoft%' THEN 'copilot'
+  WHEN properties.$referrer LIKE '%facebook%' OR properties.$referrer LIKE '%instagram%' OR properties.$referrer LIKE '%t.co%' OR properties.$referrer LIKE '%reddit%' THEN 'social'
+  WHEN properties.$referrer = '$direct' OR properties.$referrer IS NULL OR properties.$referrer = '' THEN 'direct'
+  ELSE 'other'
+END AS channel
+```
+
+AI engines isolated as their own buckets (per issue #308 tile 4).
+
+## Decisions
+
+1. **HYBRID approach** as suggested:
+   - 10 new HogQL subcommands in `posthog-query.sh` (CLI surface, exact same SQL as dashboard).
+   - `scripts/posthog-dashboard-config.json` with 10 insight definitions ready to POST.
+   - `scripts/posthog-create-dashboard.sh` to build the dashboard via API.
+2. **Project id**: hardcode `275753` (matches `posthog-baseline.sh`).
+3. **Auth**: same `POSTHOG_PERSONAL_API_KEY` pattern (no new envs).
+4. **Output format**: compact CSV-ish printed to stdout for diffing.
+5. **No backward-compatibility risk**: subcommands are additive; existing commands (`events`, `scroll`, `affiliate`, …) untouched.
+6. **`posthog-baseline.sh` integration**: leave as-is. It already captures pageview/affiliate/exception/engagement scalars. Adding the new dashboard doesn't require rewriting it. (Future enhancement — out of scope for #308.)

--- a/specs/issue-308-posthog-dashboard/tasks.md
+++ b/specs/issue-308-posthog-dashboard/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — Issue #308 PostHog Dashboard
+
+- [ ] T1. Refactor `posthog-query.sh` to add a `hogql_table` helper that python-encodes SQL into the request body (avoid the `'"'"'` escaping mess).
+- [ ] T2. Append 10 new subcommands using the helper, each running its canonical HogQL.
+- [ ] T3. Update the help/usage block at the bottom of `posthog-query.sh` to list the 10 new commands grouped under "Traffic-growth dashboard tiles".
+- [ ] T4. Write `scripts/posthog-dashboard-config.json` with the same 10 queries wrapped in `DataTableNode` insight definitions.
+- [ ] T5. Write `scripts/posthog-create-dashboard.sh` that POSTs the config to PostHog and prints the dashboard URL.
+- [ ] T6. Make scripts executable (`chmod +x`).
+- [ ] T7. Smoke-test: run one subcommand (`channel-mix`) to confirm auth + query path works.
+- [ ] T8. Run `posthog-create-dashboard.sh` to create the live dashboard. Capture the URL.
+- [ ] T9. Commit, push, open PR with body referencing #308 and #283.
+- [ ] T10. Squash-merge with --admin.


### PR DESCRIPTION
Closes #308. Refs #283.

## Summary

Builds the measurement infrastructure for EPIC #283. Promoted from Phase 5 → Phase 1 so per-PR baselines can be captured before phases 1-4 ship.

**Live dashboard:** https://us.posthog.com/project/275753/dashboard/1511831

## What's in the box

- **10 HogQL subcommands** added to `scripts/posthog-query.sh` (`channel-mix`, `daily-pv`, `affiliate-by-channel`, `ai-search`, `top-pv`, `top-ctr`, `engagement-watchdog`, `exception-watchdog`, `newsletter-signups`, `device-cr`).
- **`scripts/posthog-dashboard-config.json`** — 10 `DataTableNode` insight definitions. Identical SQL to the CLI subcommands (single source of truth).
- **`scripts/posthog-create-dashboard.sh`** — POSTs the config to PostHog's `/dashboards/` + `/insights/` APIs and prints the resulting URL.
- New `hogql_table` helper in `posthog-query.sh` sidesteps the awkward `'"'"'` shell-escape pattern by python-encoding the SQL into the request body — keeps the new subcommands readable.

## Verification

All 10 subcommands smoke-tested against live data. Examples:

- `channel-mix`: google 58.7%, direct 39.9%, other/bing/duckduckgo/social = 1.4% combined.
- `top-pv`: dosage-guide (460 PV), hangover-supplements-complete-guide (350), rct-2024 (313).
- `top-ctr`: `/reviews` 80% CTR, `/compare` 8.3%.
- `newsletter-signups`: 0 today (expected — wires up via #285).
- `ai-search`: empty today — establishes the zero-baseline for tracking AI referrer growth.

## Test plan

- [x] Bash syntax check on both scripts
- [x] Smoke-test each of the 10 subcommands with live API key
- [x] `posthog-create-dashboard.sh` ran end-to-end, dashboard 1511831 created with all 10 insights attached
- [x] Verify dashboard URL renders all tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)