### PR TITLE
feat: emit BreadcrumbList JSON-LD + remove duplicate Article schema (#290)

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,40 +133,9 @@
 
     <!-- Note: FAQ schema is added by FAQSection component on homepage -->
     <!-- Other pages add FAQ schema via prerender scripts to avoid duplicates -->
-    
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "Article",
-      "headline": "The Complete Guide to DHM (Dihydromyricetin) for Hangover Prevention",
-      "description": "Comprehensive guide covering DHM's mechanism of action, clinical studies, safety profile, and product reviews",
-      "author": {
-        "@type": "Organization",
-        "name": "DHM Guide"
-      },
-      "publisher": {
-        "@type": "Organization",
-        "name": "DHM Guide",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://www.dhmguide.com/logo.png"
-        }
-      },
-      "datePublished": "2025-01-01",
-      "dateModified": "2025-06-28",
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "https://www.dhmguide.com"
-      },
-      "image": {
-        "@type": "ImageObject",
-        "url": "https://www.dhmguide.com/dhm-guide-featured.jpg"
-      },
-      "articleSection": "Health & Wellness",
-      "keywords": ["DHM", "Dihydromyricetin", "Hangover Prevention", "Liver Protection", "Natural Supplements"]
-    }
-    </script>
-    
+    <!-- Note: Article JSON-LD is emitted per-post by scripts/prerender-blog-posts-enhanced.js -->
+    <!-- (issue #290: removed duplicate site-wide Article schema that triggered GSC warnings) -->
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -57,7 +57,7 @@
   <!-- Blog Posts (189 total) -->
   <url>
     <loc>https://www.dhmguide.com/never-hungover/activated-charcoal-hangover</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -273,7 +273,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/antioxidant-anti-aging-dhm-powerhouse-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -297,7 +297,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/bachelor-bachelorette-party-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -321,19 +321,19 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/british-pub-culture-guide</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/broke-college-student-budget-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/business-dinner-networking-dhm-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -345,13 +345,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/business-travel-dhm-survival-kit-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/can-you-take-dhm-every-day-long-term-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -369,7 +369,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/client-entertainment-sales-mastery-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -381,13 +381,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/college-student-dhm-guide-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/college-to-career-transition-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -405,13 +405,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/conference-networking-dhm-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/consultant-client-site-success-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -423,7 +423,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/dhm-adults-over-50-age-related-safety-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -435,7 +435,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/dhm-availability-worldwide-guide-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -477,7 +477,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/dhm-safety-complete-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -489,7 +489,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/dhm-supplement-stack-guide-complete-combinations</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -501,7 +501,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/dhm-vs-prickly-pear-hangovers</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -531,13 +531,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/double-wood-dhm-review-analysis</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/double-wood-dhm-vs-dhm1000-comparison-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -585,7 +585,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/emergency-hangover-protocol-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -603,19 +603,19 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/executive-travel-wellness-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/fatty-liver-disease-complete-guide-causes-symptoms-natural-treatment-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/fatty-liver-disease-diet-complete-nutrition-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -633,7 +633,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/fitness-enthusiast-social-drinking-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -657,7 +657,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/flyby-vs-double-wood-complete-comparison-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -675,25 +675,25 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/flyby-vs-no-days-wasted-complete-comparison-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/flyby-vs-nusapure-complete-comparison-2025</loc>
-    <lastmod>2025-11-27</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/flyby-vs-toniiq-ease-complete-comparison-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/french-wine-culture-guide</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -729,19 +729,19 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/german-beer-culture-guide</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/good-morning-hangover-pills-review-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/greek-life-success-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -753,7 +753,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/hangover-career-impact-dhm-solution-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -783,7 +783,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/heavy-drinking-maximum-protection-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -801,7 +801,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/how-long-does-hangover-last</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -819,31 +819,31 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/how-to-get-rid-of-hangover-fast</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/international-business-success-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/is-dhm-safe-science-behind-side-effects-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/italian-drinking-culture-guide</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/liver-health-alcohol-supplements-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -861,7 +861,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/liver-inflammation-causes-symptoms-natural-treatment-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -879,13 +879,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/mindful-drinking-wellness-warrior-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/music-festival-survival-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -909,13 +909,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/no-days-wasted-dhm-review-analysis</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/no-days-wasted-vs-cheers-restore-dhm-comparison-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -957,7 +957,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/non-alcoholic-fatty-liver-disease-nafld-prevention-management-guide-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -969,13 +969,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/nusapure-dhm-review-analysis</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/organic-natural-hangover-prevention-clean-living-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -993,7 +993,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/pre-game-party-strategy-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -1035,7 +1035,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/salary-negotiation-performance-dhm-2025</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -1077,7 +1077,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/social-media-influencer-party-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -1089,7 +1089,7 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/spanish-drinking-culture-guide</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1101,25 +1101,25 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/study-abroad-international-student-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/summer-alcohol-consumption-dhm-safety-guide</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/tequila-hangover-truth</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/toniiq-ease-dhm-review-analysis</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -1167,13 +1167,13 @@
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/wine-hangover-guide</loc>
-    <lastmod>2026-02-01</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.dhmguide.com/never-hungover/work-life-balance-dhm-2025</loc>
-    <lastmod>2025-11-07</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/scripts/prerender-blog-posts-enhanced.js
+++ b/scripts/prerender-blog-posts-enhanced.js
@@ -13,7 +13,7 @@ import jsdom from 'jsdom';
 import { micromark } from 'micromark';
 import { gfm, gfmHtml } from 'micromark-extension-gfm';
 import { generateFAQSchema } from '../src/utils/productSchemaGenerator.js';
-import { generateHowToSchema } from '../src/utils/structuredDataHelpers.js';
+import { generateHowToSchema, generateBreadcrumbSchema } from '../src/utils/structuredDataHelpers.js';
 import { getDateModified } from './lib/get-date-modified.js';
 
 const { JSDOM } = jsdom;
@@ -158,6 +158,17 @@ async function prerenderPost(post, baseHtml, blogDistDir) {
   scriptTag.type = 'application/ld+json';
   scriptTag.textContent = JSON.stringify(structuredData);
   document.head.appendChild(scriptTag);
+
+  // Add BreadcrumbList schema (Home → Never Hungover → <post title>)
+  // Eligible for Google breadcrumb rich result; uses safeTitle (escaped).
+  const breadcrumbSchema = generateBreadcrumbSchema({
+    path: `/never-hungover/${post.slug}`,
+    pageTitle: safeTitle
+  });
+  const breadcrumbScript = document.createElement('script');
+  breadcrumbScript.type = 'application/ld+json';
+  breadcrumbScript.textContent = JSON.stringify(breadcrumbSchema);
+  document.head.appendChild(breadcrumbScript);
 
   // Add FAQ schema if available for this post
   // Priority: 1) post.faq array in JSON, 2) hardcoded faqData by slug

--- a/scripts/prerender-main-pages.js
+++ b/scripts/prerender-main-pages.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { JSDOM } from 'jsdom';
+import { generateBreadcrumbSchema } from '../src/utils/structuredDataHelpers.js';
 
 // Main pages to prerender with their unique meta data
 const pages = [
@@ -178,6 +179,15 @@ async function prerenderMainPages() {
         faqScript.textContent = JSON.stringify(page.faqSchema);
         document.head.appendChild(faqScript);
       }
+
+      // Add BreadcrumbList schema (eligible for Google breadcrumb rich result).
+      // Helper handles the home page case (single Home item) and named segments
+      // ('reviews' → 'Reviews', 'guide' → 'DHM Guide', etc.).
+      const breadcrumbSchema = generateBreadcrumbSchema({ path: page.route });
+      const breadcrumbScript = document.createElement('script');
+      breadcrumbScript.setAttribute('type', 'application/ld+json');
+      breadcrumbScript.textContent = JSON.stringify(breadcrumbSchema);
+      document.head.appendChild(breadcrumbScript);
 
       // Determine output directory and file path
       const outputDir = page.route === '/' ? distDir : path.join(distDir, page.route);

--- a/specs/issue-290-breadcrumb/plan.md
+++ b/specs/issue-290-breadcrumb/plan.md
@@ -1,0 +1,13 @@
+# [Phase 2] BreadcrumbList JSON-LD + dedupe Article schema
+
+Refs #283.
+
+## Tasks (~1 hr)
+1. Add BreadcrumbList JSON-LD emission to scripts/prerender-blog-posts-enhanced.js (Home → Never Hungover → post)
+2. Remove duplicate Article JSON-LD from index.html (prerender script already injects one)
+
+Avoids GSC 'multiple Article' warnings + makes site eligible for breadcrumb rich result.
+
+Source: synthesis-S2, 08-technical-seo.md quick wins #2-3.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-290-breadcrumb/research.md
+++ b/specs/issue-290-breadcrumb/research.md
@@ -1,0 +1,47 @@
+# Research — Issue #290: BreadcrumbList + dedupe Article
+
+## Findings
+
+### 1. Duplicate Article schema source
+- `index.html` lines 137-168: hard-coded generic Article JSON-LD ("The Complete Guide to DHM (Dihydromyricetin) for Hangover Prevention"). This is built into `dist/index.html` and inherited by every prerendered post via JSDOM.
+- `scripts/prerender-blog-posts-enhanced.js` lines 130-160: per-post Article JSON-LD (`headline`, `datePublished`, `dateModified`, post-specific image, etc.). Richer, post-accurate.
+
+**Verified duplicate**: `dist/never-hungover/dhm-dosage-guide-2025/index.html` contains 2 `"@type": "Article"` matches (regex with `\s*`):
+- one indented (from base HTML)
+- one minified (injected by prerender)
+
+→ **Decision: keep prerender per-post Article, delete the static one in `index.html`.**
+
+### 2. BreadcrumbList helper already exists
+- `src/utils/structuredDataHelpers.js` lines 237-311: `generateBreadcrumbSchema({ path, pageTitle })`.
+- Used client-side only via `src/hooks/useSEO.js` (lines 133, 162, 188, 213, 232, 250, 272, 290, 353).
+- **Crawlers do not see it** — it's appended after hydration, not in prerendered HTML.
+
+**Spec wants:** `Home → Never Hungover → <post title>`.
+**Helper currently emits:** `Home → Blog → <post title>` (segmentNames maps `'never-hungover': 'Blog'`).
+
+→ Update `segmentNames['never-hungover']` to `'Never Hungover'` in helper to match spec, naturally aligning client-side and prerender output.
+
+### 3. Main pages prerender
+- `scripts/prerender-main-pages.js` covers `/`, `/guide`, `/reviews`, `/research`, `/about`, `/dhm-dosage-calculator`, `/compare`. Currently emits **no JSON-LD** beyond what's inherited from base `index.html` (and one optional FAQ for `/research`).
+- After deleting static Article from `index.html`, main pages will no longer carry an Article schema. Spec wants BreadcrumbList added for these → use `generateBreadcrumbSchema`.
+
+### 4. Other static schemas in index.html (KEEP)
+- WebSite (line 106-132) — site-wide, valid on all pages
+- Product / AggregateRating (line 170-212) — aggregate review across DHM supplements; appropriate site-wide for DHM Guide
+- Organization (line 215-231) — knowledge panel signal
+
+→ **Only the Article block (lines 137-168) is the duplicate. Delete it.**
+
+## Plan
+1. Edit `src/utils/structuredDataHelpers.js`: remap `'never-hungover'` → `'Never Hungover'`.
+2. Edit `scripts/prerender-blog-posts-enhanced.js`: import `generateBreadcrumbSchema`, emit `<script type="application/ld+json">` for each post (`Home → Never Hungover → post title`).
+3. Edit `scripts/prerender-main-pages.js`: import helper, emit BreadcrumbList per route.
+4. Edit `index.html`: delete the static Article JSON-LD (lines 137-168) plus surrounding comments.
+5. `npm run build` + verify grep counts.
+
+## Acceptance criteria
+- `grep -cE '"@type":\s*"Article"' dist/index.html` → `0` (was 1)
+- `grep -cE '"@type":\s*"Article"' dist/never-hungover/<any>/index.html` → `1` (was 2)
+- `grep -cE '"@type":\s*"BreadcrumbList"' dist/never-hungover/<any>/index.html` → `1` (was 0)
+- `grep -cE '"@type":\s*"BreadcrumbList"' dist/reviews/index.html` → `1` (was 0)

--- a/src/utils/structuredDataHelpers.js
+++ b/src/utils/structuredDataHelpers.js
@@ -269,7 +269,7 @@ export const generateBreadcrumbSchema = ({ path, pageTitle }) => {
     'research': 'Research',
     'compare': 'Compare',
     'about': 'About',
-    'never-hungover': 'Blog',
+    'never-hungover': 'Never Hungover',
     'dhm-dosage-calculator': 'Dosage Calculator'
   };
 


### PR DESCRIPTION
## Summary

Two SEO fixes in one PR:

1. **Add BreadcrumbList JSON-LD** to prerendered HTML for blog posts and main pages. Eligible for Google breadcrumb rich results.
   - Blog posts: `Home → Never Hungover → <post title>`
   - Main pages: `Home → Reviews`, `Home → DHM Guide`, `Home → Compare`, etc.
   - Reuses existing `generateBreadcrumbSchema` helper in `src/utils/structuredDataHelpers.js`.
2. **Remove duplicate Article JSON-LD** from `index.html`. The prerender script already injects a richer per-post Article schema; the static block was inherited site-wide and triggered GSC "multiple Article" warnings on every blog post.

Also fixes the segment-name mapping: `'never-hungover' → 'Never Hungover'` (was `'Blog'`), aligning client-side and prerendered breadcrumbs.

## Verification (post-build grep counts)

| File | Before | After |
|------|--------|-------|
| `dist/index.html` Article | 1 | 0 |
| `dist/index.html` BreadcrumbList | 0 | 1 |
| `dist/never-hungover/<post>/index.html` Article | 2 | 1 |
| `dist/never-hungover/<post>/index.html` BreadcrumbList | 0 | 1 |
| `dist/reviews/index.html` BreadcrumbList | 0 | 1 |

Sample blog breadcrumb (from `dhm-dosage-guide-2025`):
```
Home → Never Hungover → DHM Dosage Guide: How Much Should I Take?
```

## Test plan

- [x] `npm run build` succeeds (189 posts + 7 main pages)
- [x] Article count: index.html 1→0, post HTML 2→1
- [x] BreadcrumbList present on homepage, blog posts, /reviews, /compare, /guide, /about
- [x] Breadcrumb path: `Home → Never Hungover → <post title>` (not `Home → Blog`)
- [ ] Validate with Google Rich Results Test post-deploy

Closes #290. Refs #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)