### PR TITLE
fix: hero image CLS - add width/height + adopt Picture component (#293)

### DIFF
--- a/specs/issue-293-hero-img/plan.md
+++ b/specs/issue-293-hero-img/plan.md
@@ -1,0 +1,15 @@
+# [Phase 2] Hero img width/height + adopt unused Picture.jsx component
+
+Refs #283. Two related fixes.
+
+## Bug 1: missing img dims
+src/newblog/components/NewBlogPost.jsx:921 — hero img has no width/height. Causes layout shift on first paint.
+
+## Bug 2: Picture.jsx never imported
+src/components/Picture.jsx exists with proper webp/lazy/fallback logic but is never imported. Adopt it for hero (and gradually for in-content images).
+
+Fix (~1 hr): add dims, replace hero img with <Picture>, verify CLS in PostHog 24h post-deploy.
+
+Source: 08-technical-seo.md quick win #1, dead-weight finding.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-293-hero-img/research.md
+++ b/specs/issue-293-hero-img/research.md
@@ -1,0 +1,62 @@
+# Research — Issue #293: Hero img dims + Picture.jsx adoption
+
+## Current state
+
+### Hero `<img>` at NewBlogPost.jsx:921
+```jsx
+{post.image && (
+  <div className="w-full">
+    <img
+      src={post.image}
+      alt={`${post.title} - DHM Guide`}
+      className="w-full aspect-video object-cover"
+      loading="eager"
+    />
+  </div>
+)}
+```
+- No `width`/`height` attrs → browser cannot reserve layout box on first paint → CLS.
+- `aspect-video` Tailwind class = `aspect-ratio: 16/9` (this wins via CSS), and `object-cover` crops the source to fit.
+- `loading="eager"` already correct for above-fold hero.
+
+### Picture.jsx at src/components/Picture.jsx
+- Exists but is NEVER imported anywhere in `src/`.
+- Logic: takes `src` (e.g. `/images/foo.png`), strips ext, emits a `<picture>` with:
+  - `<source srcSet="{base}.webp" type="image/webp">`
+  - `<source srcSet="{base}{originalExt}" type="image/{ext}">`
+  - `<img src="{base}{originalExt}">`
+- Loading: `priority=true` → `loading="eager"`, `decoding="sync"`. Else lazy + async.
+- **Bug for our use case**: when `src` ends in `.webp`, `originalExt` falls through to `.png`. Result: `<img src="/images/foo.png">` — the PNG file does NOT exist on disk for our 141 `.webp` heroes. Modern browsers will pick the webp `<source>` so the user sees the right image, but the `<img>` fallback is wrong (would 404 if user disabled webp).
+- **Does not accept `width`/`height` as named props**, but `...props` spread allows them through to the `<img>`.
+
+### Image data shape across 189 posts
+- `"image": "<string url>"`: 142 posts (139 webp, 2 jpg, no png)
+- `"image": null`: 46 posts (Issue #38 fix)
+- `"image": <object>`: 0 (was 8, fixed in Issue #38)
+- All hero images live in `/public/images/`.
+
+### Hero image dimensions (ON DISK)
+- 1536x1024: 247 files (most common, 3:2 aspect)
+- 1200x672, 1232x928, 1200x630, 1000x667: <30 files combined
+- All rendered into a 16:9 box via `aspect-video` + `object-cover`.
+
+### Other `<img>` in NewBlogPost.jsx
+- Line 1461: related-posts thumbnails (`h-32 object-cover`, lazy). Out of scope for hero CLS fix; can adopt Picture in a follow-up.
+
+## Key decisions
+
+1. **Width/height attrs**: Use `1600x900` (16:9) to match the `aspect-video` rendered box. Browser applies `aspect-ratio: auto 1600 / 900` to the `<img>` if no other CSS overrides it. Tailwind `aspect-video` sets `aspect-ratio: 16/9` which is identical → no conflict, no CLS.
+
+2. **Picture.jsx adoption strategy**: Since 99% of our hero images are already `.webp` (no PNG/JPG fallback file exists), wrapping them in a `<picture>` element that emits a phantom `.png` source is actively harmful. Two options:
+   - **(A) Patch Picture.jsx** to detect `.webp` input and emit only a single `<source>` + `<img src={originalWebp}>`.
+   - **(B) Skip Picture.jsx**, just add `width`/`height`/`fetchpriority="high"` to the existing `<img>`.
+   - **Decision: A** — preserves the spec goal of adopting Picture.jsx, fixes the latent bug, and keeps the spec tightly scoped (~10 lines of Picture.jsx).
+
+3. **Null image handling**: Wrapped in `{post.image && (...)}` — Picture is only rendered when `post.image` is truthy. Inside Picture, `src` is always a string. Safe.
+
+4. **Priority/eager**: Hero is above-fold LCP candidate → pass `priority={true}` → eager loading + sync decoding + we'll also pass `fetchpriority="high"` via `...props`.
+
+## Out of scope
+- Related-post thumbnail `<img>` (line 1461) — defer to follow-up.
+- Markdown content `<img>` rewriting — defer.
+- New webp generation for the 2 `.jpg` images — they already render fine; Picture's logic for `.jpg → .webp` source + `.jpg` fallback is correct shape (though the `.webp` companion file may not exist; we accept the existing `.jpg` will be served via the `<img>` fallback).

--- a/src/components/Picture.jsx
+++ b/src/components/Picture.jsx
@@ -1,40 +1,77 @@
 import React from 'react'
 
-export default function Picture({ 
-  src, 
-  alt, 
-  className, 
+/**
+ * Responsive <picture> with webp source + original fallback.
+ *
+ * - If `src` ends in .webp, emits a single webp <source> + <img src={webp}>.
+ *   (We don't synthesize a .png/.jpg fallback because those files don't exist
+ *   on disk for our webp-native heroes — would 404 on browsers without webp,
+ *   though all modern browsers support it.)
+ * - If `src` ends in .png/.jpg/.jpeg, emits a webp <source> (assumed to exist
+ *   alongside) + an original-format <source> + <img> fallback.
+ *
+ * Pass `width` and `height` to prevent CLS — browser uses them to compute
+ * the layout box before the image loads.
+ */
+export default function Picture({
+  src,
+  alt,
+  className,
   loading = "lazy",
   sizes,
   priority = false,
-  ...props 
+  width,
+  height,
+  ...props
 }) {
-  // Extract base path and extension
-  const basePath = src.replace(/\.(png|jpg|jpeg|webp)$/i, '');
-  const originalExt = src.match(/\.(png|jpg|jpeg)$/i)?.[0] || '.png';
-  
-  // Use eager loading for priority images
   const loadingStrategy = priority ? "eager" : loading;
-  
+  const decoding = priority ? "sync" : "async";
+
+  const isWebp = /\.webp$/i.test(src);
+  const basePath = src.replace(/\.(png|jpg|jpeg|webp)$/i, '');
+  const originalExtMatch = src.match(/\.(png|jpg|jpeg)$/i);
+  const originalExt = originalExtMatch?.[0];
+
+  if (isWebp) {
+    // Native webp: just one source + img, no synthetic fallback.
+    return (
+      <picture>
+        <source srcSet={src} type="image/webp" sizes={sizes} />
+        <img
+          src={src}
+          alt={alt}
+          className={className}
+          loading={loadingStrategy}
+          decoding={decoding}
+          sizes={sizes}
+          width={width}
+          height={height}
+          {...props}
+        />
+      </picture>
+    );
+  }
+
+  // PNG/JPG source: emit webp companion (if it exists on disk) + original.
   return (
     <picture>
-      <source 
-        srcSet={`${basePath}.webp`} 
-        type="image/webp"
-        sizes={sizes}
-      />
-      <source 
-        srcSet={`${basePath}${originalExt}`} 
-        type={`image/${originalExt.slice(1)}`}
-        sizes={sizes}
-      />
-      <img 
-        src={`${basePath}${originalExt}`} 
-        alt={alt} 
+      <source srcSet={`${basePath}.webp`} type="image/webp" sizes={sizes} />
+      {originalExt && (
+        <source
+          srcSet={src}
+          type={`image/${originalExt.slice(1).replace('jpg', 'jpeg')}`}
+          sizes={sizes}
+        />
+      )}
+      <img
+        src={src}
+        alt={alt}
         className={className}
         loading={loadingStrategy}
-        decoding={priority ? "sync" : "async"}
+        decoding={decoding}
         sizes={sizes}
+        width={width}
+        height={height}
         {...props}
       />
     </picture>

--- a/src/newblog/components/NewBlogPost.jsx
+++ b/src/newblog/components/NewBlogPost.jsx
@@ -19,6 +19,7 @@ import { applyRedirect } from '../../utils/redirects.js';
 import { usePageTracking } from '../../hooks/usePageTracking';
 import KeyTakeaways from './KeyTakeaways';
 import ImageLightbox from './ImageLightbox';
+import Picture from '../../components/Picture';
 import { Link as CustomLink } from '../../components/CustomLink';
 import { trackElementClick } from '../../lib/posthog';
 import { motion } from 'framer-motion';
@@ -915,14 +916,17 @@ const NewBlogPost = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="bg-white rounded-xl shadow-lg overflow-hidden">
-            {/* Hero Image - uses aspect-video for consistent ratio and no CLS */}
+            {/* Hero Image - aspect-video + width/height attrs prevent CLS (Issue #293) */}
             {post.image && (
               <div className="w-full">
-                <img
+                <Picture
                   src={post.image}
                   alt={`${post.title} - DHM Guide`}
                   className="w-full aspect-video object-cover"
-                  loading="eager"
+                  width={1600}
+                  height={900}
+                  priority
+                  fetchpriority="high"
                 />
               </div>
             )}


### PR DESCRIPTION
Closes #293. Refs #283.

## Problem
Hero `<img>` on every blog post had no `width`/`height` attrs. Browsers couldn't reserve the layout box on first paint, causing layout shift (CLS) as the image loaded.

Separately, `src/components/Picture.jsx` existed in the codebase but was never imported anywhere — so all of its lazy/webp/fallback logic was dead code.

## Fix
**1. Swap hero `<img>` for `<Picture>`** in `src/newblog/components/NewBlogPost.jsx:921`
**2. Patch latent bug in `Picture.jsx`** — when `src` ended in `.webp` it synthesized a phantom `.png` fallback that doesn't exist on disk for our 141 webp-native heroes. Now webp-native sources emit a single `<source>` + `<img>`; png/jpg sources still get the webp companion + original-format fallback as originally designed.

## Before/after rendered HTML

Before (NewBlogPost.jsx:921):
```jsx
<img
  src={post.image}
  alt="..."
  className="w-full aspect-video object-cover"
  loading="eager"
/>
```

After:
```jsx
<Picture
  src={post.image}
  alt="..."
  className="w-full aspect-video object-cover"
  width={1600}
  height={900}
  priority
  fetchpriority="high"
/>
```

Rendered HTML for a webp hero:
```html
<picture>
  <source srcSet="/images/foo-hero.webp" type="image/webp">
  <img src="/images/foo-hero.webp" alt="..." class="w-full aspect-video object-cover"
       loading="eager" decoding="sync" width="1600" height="900" fetchpriority="high">
</picture>
```

## Why 1600×900?
The rendered hero is forced into a 16:9 box by the existing Tailwind `aspect-video` class with `object-cover` cropping. Width/height attrs of 1600×900 match that visual aspect, so the browser reserves the right box on first paint regardless of the underlying source dimensions (most heroes are 1536×1024 = 3:2, but they're cropped to fit).

## Null-image posts
~46 of 189 posts have `image: null` (after Issue #38 fix). They're already guarded by the existing `{post.image && (...)}` wrapper around the `<Picture>` call. Behavior unchanged.

## Verification
- `npm run build` -> green, 189/189 posts prerendered.
- Bundle inspection: `width:1600,height:900` baked into `dist/assets/NewBlogPost-*.js`.
- Picture component compiled with both webp and png/jpg branches.

## Out of scope (defer)
- Related-post thumbnails at `NewBlogPost.jsx:1461` (also raw `<img>`) — Picture adoption can land in a follow-up.
- CLS PostHog `$web_vitals` validation requires production deploy + 24h of traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)