### PR TITLE
feat: mega-menu nav surfaces 6 cluster pillars (#298)

### DIFF
--- a/specs/issue-298-mega-menu/design.md
+++ b/specs/issue-298-mega-menu/design.md
@@ -1,0 +1,67 @@
+# Design: Issue #298 — Mega-menu nav dropdown
+
+## Approach
+Build inline mega-menu in Layout.jsx using existing Tailwind + framer-motion patterns. Avoid Radix primitives (paradigm shift, extra deps already imported but unused in this Layout).
+
+## Data flow
+1. Import `clusterConfig` from `/scripts/cluster-config.json` at module level (Vite handles JSON, ~3KB)
+2. Derive cluster display label from `cluster.name` via `kebabToTitle()` util
+3. Derive spoke link label from slug via `slugToTitle()` util (kebab + remove year + Title Case + clean)
+4. Take first 5 spokes per cluster (`cluster.spokes.slice(0, 5)`)
+5. Pillar link → `/never-hungover/{cluster.pillar}` (special case: dhm-dosage-guide-2025 lives there too)
+6. Spoke link → `/never-hungover/{spoke}`
+
+## Component structure (within Layout.jsx)
+- New util: `kebabToTitle(s)` — `dhm-master` → `DHM Master`
+- New util: `slugToSpokeTitle(slug)` — strips trailing `-2025`/year, Title-Cases, replaces hyphens with spaces, ensures common acronyms (DHM, NAC, BAC, REM, GI) are uppercase
+- Inline `<TopicsDropdown />` component (or kept inline JSX) — desktop dropdown panel
+- Mobile: nested collapsible block inside existing mobile nav
+
+## Replacement strategy
+- Filter out `/never-hungover` route from `navItems` rendering
+- Insert new "Topics" dropdown trigger in its place (same loop position)
+- The dropdown's "Topics" label → links to `/never-hungover` (preserves direct hub access)
+
+## Desktop dropdown UI
+- Trigger: `<button>` styled like nav link, with ChevronDown icon
+- On hover OR focus → open panel
+- Panel: absolute positioned below trigger, `mt-2`, full-width container, max-w-6xl, white bg, shadow-xl, rounded-lg, p-6
+- Grid: `grid-cols-3 gap-6` (2 rows × 3 cols)
+- Each cluster section:
+  - `<a>` linked to pillar slug — bold cluster name, hover highlight, with arrow
+  - `<ul>` of 5 spoke links underneath, smaller text, gray hover
+- Close on: mouse leave, escape key, link click
+- z-index above page content (`z-50`)
+
+## Mobile UI
+- Inside existing mobile nav, replace the "Never Hungover" link with collapsible "Topics" header
+- Tap header → expand/collapse (arrow flips)
+- Expanded: list 6 clusters, each with cluster name (linked to pillar) + spokes underneath
+- Use `useState` to track which cluster section is expanded (null or cluster name)
+
+## A11y
+- Trigger: `aria-haspopup="true"`, `aria-expanded={isOpen}`, `aria-controls="topics-panel"`
+- Panel: `role="region"`, `id="topics-panel"`
+- Escape closes
+- Focus styles preserved on all links
+- Hover-only is bad — also open on focus (`onFocus`) and click (toggle)
+- Keyboard: Tab moves to trigger, Enter opens, Tab through links, Escape closes
+
+## State
+- `isTopicsOpen` (bool, desktop)
+- `expandedClusterMobile` (string|null, mobile)
+- Close logic on outside click / escape
+
+## Auto-derivation guarantee
+Adding/modifying a cluster in `cluster-config.json` automatically:
+- Adds new section to dropdown
+- Updates pillar link
+- Updates spoke list
+- No code changes required
+
+## Things NOT doing (cut for simplicity)
+- Per-cluster icons — adds 6 more imports, marginal value
+- Visit counts / "popular" badges — no data source
+- "View all in this topic" link — pillar IS the view-all
+- Animated entrance per cluster — single fade is enough
+- Persisting open state in URL — overkill

--- a/specs/issue-298-mega-menu/plan.md
+++ b/specs/issue-298-mega-menu/plan.md
@@ -1,0 +1,18 @@
+# [Phase 2] Layout.jsx mega-menu dropdown — surface 6 cluster pillars in nav
+
+Refs #283. T4 found NO blog posts in primary nav — all 189 hidden behind /never-hungover hub.
+
+## Dependencies
+
+- **Blocked by #295** (cluster-config.json producer)
+- **Blocked by #297** (cluster pillar/spoke structure must be formalized before nav surfaces it)
+
+
+## Fix (~3 hrs)
+Add mega-menu dropdown to src/components/layout/Layout.jsx exposing the 6 cluster pillars. Each shows pillar post + 3-5 top spokes. Auto-derived from cluster-config.json — zero-maintenance.
+
+Expected uplift: +3-5% blog traffic from broader internal-link reach.
+
+Source: synthesis-S3 Intervention 5.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/specs/issue-298-mega-menu/research.md
+++ b/specs/issue-298-mega-menu/research.md
@@ -1,0 +1,77 @@
+# Research: Issue #298 — Mega-menu nav dropdown
+
+## Current state of `src/components/layout/Layout.jsx`
+- 309 lines, single component, exports `React.memo(Layout)`
+- Uses `useRouter()` hook (`src/hooks/useRouter.js`) — single source of truth for ROUTES
+- Nav items derived from `getNavItems()` which filters `ROUTES` by `inNav: true`
+- Currently shows 7 nav items (Home, Hangover Relief, Best Supplements, Compare Solutions, The Science, Never Hungover, About) at lines 73-100
+- Mobile: hamburger toggle in `useState(isMenuOpen)` at line 11; collapsible nav block lines 139-186
+- Styling: Tailwind utilities, framer-motion for active-tab indicator, no separate CSS files
+- Header styling: `bg-white/80 backdrop-blur-md border-b border-green-100`, `z-header`, fixed
+- Hover state: `text-gray-600 hover:text-green-600`
+- `ChevronDown` icon NOT currently used in Layout.jsx
+
+## Cluster config (`scripts/cluster-config.json`)
+- 6 clusters: dhm-master, liver-health, health-impact, alcohol-science, hangover-prevention, product-reviews
+- Each cluster has: `name` (kebab-case), `pillar` (slug), `spokes[]` (array of slugs)
+- Spoke counts: 7, 7, 10, 7, 8, 8 (range 7-10)
+- Pillars and spokes are post slugs, NOT URLs — URL pattern is `/never-hungover/{slug}`
+- Exception: `dhm-master` pillar slug `dhm-dosage-guide-2025` — also lives at `/never-hungover/dhm-dosage-guide-2025`
+
+## Existing dropdown components
+- `src/components/ui/navigation-menu.jsx` — Radix-based, full a11y, exists but unused in Layout
+- `src/components/ui/dropdown-menu.jsx`, `menubar.jsx`, `context-menu.jsx` — also Radix-based
+- Decision: building inline (lightweight, matches existing style) is simpler than adopting Radix — Layout already uses framer-motion + plain `<a>` tags. Adding Radix changes paradigm.
+- However for a11y (keyboard nav, focus trap, escape-to-close), self-built solution needs care
+
+## Post titles source
+- `src/newblog/data/metadata/index.json` has all post titles indexed by slug
+- 189 entries. Loading entire file into Layout would bloat bundle.
+- Alternative: hardcode display titles in cluster-config.json OR derive from slug
+- BEST: use `cluster.name` (Title-Case-d) for cluster label + format spoke slugs to titles
+- Even simpler: hardcode 6 cluster display labels + use slug-as-label OR fetch lazily
+
+## Mobile pattern
+- Existing hamburger uses `useState(isMenuOpen)` toggle
+- Mobile nav is full-width vertical list with `flex flex-col space-y-3`
+- Mobile mega-menu: nest cluster sections inside the existing mobile menu (collapsible per cluster, or just show all expanded)
+
+## Build verification
+- `npm run build` runs Vite build, prerenders many static pages
+- Need to verify nav HTML is in prerendered `dist/index.html`
+
+## Implementation approach (simplest path)
+1. Import `cluster-config.json` directly (pure data, ~3KB)
+2. Import metadata index.json for spoke titles (single fetch at build time, tree-shakeable to titles only? or hardcode mapping)
+3. Replace `Never Hungover` nav item (path `/never-hungover`) with a "Topics" dropdown
+4. Keep all other nav items unchanged
+5. Desktop: hover-to-open mega-panel, 3-column grid showing 6 clusters (2 rows × 3 cols)
+6. Each cluster panel shows: cluster header (clickable → pillar URL) + 3-5 spoke links
+7. Mobile: nest "Topics" as expandable section inside hamburger menu
+8. Use slug-derived titles for spokes (kebab → Title Case) — zero-maintenance
+9. Display label for cluster: format `cluster.name` (e.g. `dhm-master` → `DHM Master`, but better hand-tweaked labels)
+
+## Display label decision
+Auto-derive from `cluster.name`:
+- `dhm-master` → "DHM Master Guide"
+- `liver-health` → "Liver Health"
+- `health-impact` → "Health Impact"
+- `alcohol-science` → "Alcohol Science"
+- `hangover-prevention` → "Hangover Prevention"
+- `product-reviews` → "Product Reviews"
+
+Simplest = kebab-to-Title-Case via small util. Auto-updates when cluster names change.
+
+## A11y requirements
+- Dropdown must open on hover (desktop) AND keyboard focus
+- Escape closes dropdown
+- Tab moves through links
+- `aria-haspopup="true"` and `aria-expanded` on trigger
+- Focus visible state on all links
+
+## Risks
+- **CLS**: dropdown panel positioned absolutely → no layout shift
+- **Mobile screen squeeze**: collapse cluster sections by default OR show all (small lists are OK)
+- **Bundle size**: cluster-config.json is ~3KB; metadata index full import would bloat — DON'T import it. Derive titles from slugs.
+- **Keyboard a11y**: need explicit focus management or Radix
+- **Decision**: Build lightweight self-contained dropdown using existing patterns; add minimal a11y attrs

--- a/specs/issue-298-mega-menu/tasks.md
+++ b/specs/issue-298-mega-menu/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Issue #298
+
+## T1: Add util functions + import cluster-config
+- Inside `src/components/layout/Layout.jsx`:
+  - Import `clusterConfig from '../../../scripts/cluster-config.json'`
+  - Add `kebabToTitle(s)` and `slugToSpokeTitle(slug)` helper functions
+
+## T2: Add desktop dropdown trigger + panel
+- Replace `/never-hungover` item rendering in desktop `<nav>` map
+- Add inline JSX: `<div onMouseEnter|onMouseLeave|onFocus>` wrapping `<button>` (Topics + ChevronDown) and `<div role="region">` panel
+- Panel uses 3-col grid with 6 cluster sections
+
+## T3: Add mobile collapsible "Topics" section
+- Replace `/never-hungover` rendering in mobile nav map
+- Use `expandedClusterMobile` state, render 6 cluster headers as buttons
+- Each button toggles its spokes list
+
+## T4: Build verification
+- `npm run build`
+- Confirm `dist/index.html` contains "Topics" + cluster links
+
+## T5: Commit + PR + merge

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,18 +1,65 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect, useRef } from 'react'
 import { motion, useScroll, useTransform } from 'framer-motion'
 import { Button } from '@/components/ui/button.jsx'
-import { Menu, X, Leaf } from 'lucide-react'
+import { Menu, X, Leaf, ChevronDown } from 'lucide-react'
 import { useRouter } from '@/hooks/useRouter'
 import { useHeaderHeight } from '@/hooks/useHeaderHeight'
 import StickyMobileCTA from '@/components/StickyMobileCTA'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag'
+import clusterConfig from '../../../scripts/cluster-config.json'
+
+// Util: kebab-case → Title Case ("dhm-master" → "DHM Master")
+const ACRONYMS = new Set(['dhm', 'nac', 'bac', 'rem', 'gi'])
+function titleCase(words) {
+  return words
+    .map(w => ACRONYMS.has(w.toLowerCase()) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+function clusterLabel(name) {
+  // dhm-master → DHM Master Guide; otherwise simple Title Case
+  if (name === 'dhm-master') return 'DHM Master'
+  if (name === 'health-impact') return 'Alcohol & Health'
+  return titleCase(name.split('-'))
+}
+// Convert post slug to readable spoke title; strip trailing year, "complete-guide", etc.
+function slugToSpokeTitle(slug) {
+  const tokens = slug
+    .replace(/-2025$/, '')
+    .replace(/-complete-guide$/, '')
+    .split('-')
+    .filter(Boolean)
+  // cap at 6 tokens for nav brevity
+  const capped = tokens.length > 6 ? tokens.slice(0, 6) : tokens
+  return titleCase(capped)
+}
+const SPOKES_PER_CLUSTER = 5
 
 function Layout({ children }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [isTopicsOpen, setIsTopicsOpen] = useState(false)
+  const [expandedClusterMobile, setExpandedClusterMobile] = useState(null)
+  const topicsRef = useRef(null)
   const { currentPath, navigate, isActive, getNavItems, getFooterItems } = useRouter()
   const { scrollY } = useScroll()
   const headerOpacity = useTransform(scrollY, [0, 100], [1, 0.95])
   const { headerRef, headerHeight } = useHeaderHeight()
+
+  // Close topics dropdown on Escape or outside click
+  useEffect(() => {
+    if (!isTopicsOpen) return
+    const onKey = (e) => { if (e.key === 'Escape') setIsTopicsOpen(false) }
+    const onClick = (e) => {
+      if (topicsRef.current && !topicsRef.current.contains(e.target)) {
+        setIsTopicsOpen(false)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onClick)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onClick)
+    }
+  }, [isTopicsOpen])
 
   // A/B Test #255: Nav CTA copy re-test (previously #134)
   const navCtaVariant = useFeatureFlag('nav-cta-copy-v1', 'control')
@@ -70,34 +117,143 @@ function Layout({ children }) {
 
             {/* Desktop Navigation */}
             <nav className="hidden lg:flex items-center space-x-6 xl:space-x-8 flex-1 justify-center max-w-4xl mx-8">
-              {navItems.map((item) => (
-                <a
-                  key={item.name}
-                  href={item.href}
-                  onClick={(e) => {
-                    // Allow Ctrl/Cmd+click for "open in new tab"
-                    if (e.metaKey || e.ctrlKey) return;
+              {navItems.map((item) => {
+                // Replace /never-hungover with mega-menu Topics dropdown
+                if (item.href === '/never-hungover') {
+                  return (
+                    <div
+                      key="topics-dropdown"
+                      ref={topicsRef}
+                      className="relative"
+                      onMouseEnter={() => setIsTopicsOpen(true)}
+                      onMouseLeave={() => setIsTopicsOpen(false)}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setIsTopicsOpen(o => !o)}
+                        onFocus={() => setIsTopicsOpen(true)}
+                        aria-haspopup="true"
+                        aria-expanded={isTopicsOpen}
+                        aria-controls="topics-mega-menu"
+                        data-track="nav-topics-trigger"
+                        className={`relative px-3 py-2 text-sm font-medium transition-colors duration-200 whitespace-nowrap inline-flex items-center gap-1 ${
+                          isActive('/never-hungover')
+                            ? 'text-green-600'
+                            : 'text-gray-600 hover:text-green-600'
+                        }`}
+                      >
+                        Topics
+                        <ChevronDown className={`w-4 h-4 transition-transform ${isTopicsOpen ? 'rotate-180' : ''}`} />
+                        {isActive('/never-hungover') && (
+                          <motion.div
+                            layoutId="activeTab"
+                            className="absolute bottom-0 left-0 right-0 h-0.5 bg-green-600"
+                            initial={false}
+                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                          />
+                        )}
+                      </button>
+                      {isTopicsOpen && (
+                        <div
+                          id="topics-mega-menu"
+                          role="region"
+                          aria-label="Topics"
+                          className="absolute left-1/2 -translate-x-1/2 top-full mt-2 w-screen max-w-4xl bg-white rounded-xl shadow-2xl border border-gray-100 p-6 z-50"
+                        >
+                          <div className="grid grid-cols-3 gap-x-6 gap-y-5">
+                            {clusterConfig.clusters.map((cluster) => {
+                              const pillarHref = `/never-hungover/${cluster.pillar}`
+                              return (
+                                <div key={cluster.name}>
+                                  <a
+                                    href={pillarHref}
+                                    onClick={(e) => {
+                                      if (e.metaKey || e.ctrlKey) return
+                                      e.preventDefault()
+                                      setIsTopicsOpen(false)
+                                      handleNavigation(pillarHref)
+                                    }}
+                                    data-track="nav-topics-cluster"
+                                    data-cluster={cluster.name}
+                                    className="block text-sm font-bold text-green-700 hover:text-green-900 mb-2 leading-tight"
+                                  >
+                                    {clusterLabel(cluster.name)} →
+                                  </a>
+                                  <ul className="space-y-1.5">
+                                    {cluster.spokes.slice(0, SPOKES_PER_CLUSTER).map((spoke) => {
+                                      const href = `/never-hungover/${spoke}`
+                                      return (
+                                        <li key={spoke}>
+                                          <a
+                                            href={href}
+                                            onClick={(e) => {
+                                              if (e.metaKey || e.ctrlKey) return
+                                              e.preventDefault()
+                                              setIsTopicsOpen(false)
+                                              handleNavigation(href)
+                                            }}
+                                            data-track="nav-topics-spoke"
+                                            data-cluster={cluster.name}
+                                            className="block text-xs text-gray-600 hover:text-green-600 leading-snug"
+                                          >
+                                            {slugToSpokeTitle(spoke)}
+                                          </a>
+                                        </li>
+                                      )
+                                    })}
+                                  </ul>
+                                </div>
+                              )
+                            })}
+                          </div>
+                          <div className="mt-5 pt-4 border-t border-gray-100">
+                            <a
+                              href="/never-hungover"
+                              onClick={(e) => {
+                                if (e.metaKey || e.ctrlKey) return
+                                e.preventDefault()
+                                setIsTopicsOpen(false)
+                                handleNavigation('/never-hungover')
+                              }}
+                              className="text-sm font-medium text-green-600 hover:text-green-800"
+                            >
+                              View all articles →
+                            </a>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )
+                }
+                return (
+                  <a
+                    key={item.name}
+                    href={item.href}
+                    onClick={(e) => {
+                      // Allow Ctrl/Cmd+click for "open in new tab"
+                      if (e.metaKey || e.ctrlKey) return;
 
-                    e.preventDefault();
-                    handleNavigation(item.href);
-                  }}
-                  className={`relative px-3 py-2 text-sm font-medium transition-colors duration-200 whitespace-nowrap ${
-                    isActive(item.href)
-                      ? 'text-green-600'
-                      : 'text-gray-600 hover:text-green-600'
-                  }`}
-                >
-                  {item.name}
-                  {isActive(item.href) && (
-                    <motion.div
-                      layoutId="activeTab"
-                      className="absolute bottom-0 left-0 right-0 h-0.5 bg-green-600"
-                      initial={false}
-                      transition={{ type: "spring", stiffness: 500, damping: 30 }}
-                    />
-                  )}
-                </a>
-              ))}
+                      e.preventDefault();
+                      handleNavigation(item.href);
+                    }}
+                    className={`relative px-3 py-2 text-sm font-medium transition-colors duration-200 whitespace-nowrap ${
+                      isActive(item.href)
+                        ? 'text-green-600'
+                        : 'text-gray-600 hover:text-green-600'
+                    }`}
+                  >
+                    {item.name}
+                    {isActive(item.href) && (
+                      <motion.div
+                        layoutId="activeTab"
+                        className="absolute bottom-0 left-0 right-0 h-0.5 bg-green-600"
+                        initial={false}
+                        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                      />
+                    )}
+                  </a>
+                )
+              })}
             </nav>
 
             {/* CTA Button */}
@@ -144,7 +300,87 @@ function Layout({ children }) {
               className="lg:hidden mt-4 pb-4 border-t border-green-100 pt-4"
             >
               <div className="flex flex-col space-y-3">
-                {navItems.map((item) => (
+                {navItems.map((item) => {
+                  // Replace /never-hungover with collapsible Topics section on mobile
+                  if (item.href === '/never-hungover') {
+                    return (
+                      <div key="topics-mobile" className="border border-green-100 rounded-lg overflow-hidden">
+                        <button
+                          type="button"
+                          onClick={() => setExpandedClusterMobile(c => c === '__topics__' ? null : '__topics__')}
+                          aria-expanded={expandedClusterMobile === '__topics__'}
+                          className={`w-full px-4 py-3 text-sm font-medium text-left min-h-[44px] flex items-center justify-between ${
+                            isActive('/never-hungover')
+                              ? 'bg-green-100 text-green-600'
+                              : 'text-gray-600 hover:bg-green-50 hover:text-green-600'
+                          }`}
+                        >
+                          <span>Topics</span>
+                          <ChevronDown className={`w-4 h-4 transition-transform ${expandedClusterMobile === '__topics__' ? 'rotate-180' : ''}`} />
+                        </button>
+                        {expandedClusterMobile === '__topics__' && (
+                          <div className="bg-green-50/50 px-2 py-2 space-y-3">
+                            {clusterConfig.clusters.map((cluster) => {
+                              const pillarHref = `/never-hungover/${cluster.pillar}`
+                              return (
+                                <div key={cluster.name} className="px-2">
+                                  <a
+                                    href={pillarHref}
+                                    onClick={(e) => {
+                                      if (e.metaKey || e.ctrlKey) return
+                                      e.preventDefault()
+                                      handleNavigation(pillarHref)
+                                    }}
+                                    data-track="nav-topics-cluster-mobile"
+                                    data-cluster={cluster.name}
+                                    className="block text-sm font-bold text-green-700 py-2"
+                                  >
+                                    {clusterLabel(cluster.name)} →
+                                  </a>
+                                  <ul className="pl-3 space-y-1 border-l-2 border-green-200">
+                                    {cluster.spokes.slice(0, SPOKES_PER_CLUSTER).map((spoke) => {
+                                      const href = `/never-hungover/${spoke}`
+                                      return (
+                                        <li key={spoke}>
+                                          <a
+                                            href={href}
+                                            onClick={(e) => {
+                                              if (e.metaKey || e.ctrlKey) return
+                                              e.preventDefault()
+                                              handleNavigation(href)
+                                            }}
+                                            data-track="nav-topics-spoke-mobile"
+                                            data-cluster={cluster.name}
+                                            className="block text-xs text-gray-700 hover:text-green-600 py-1.5 min-h-[32px]"
+                                          >
+                                            {slugToSpokeTitle(spoke)}
+                                          </a>
+                                        </li>
+                                      )
+                                    })}
+                                  </ul>
+                                </div>
+                              )
+                            })}
+                            <div className="px-2 pt-2 border-t border-green-200">
+                              <a
+                                href="/never-hungover"
+                                onClick={(e) => {
+                                  if (e.metaKey || e.ctrlKey) return
+                                  e.preventDefault()
+                                  handleNavigation('/never-hungover')
+                                }}
+                                className="block text-sm font-medium text-green-600 py-2"
+                              >
+                                View all articles →
+                              </a>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  }
+                  return (
                   <a
                     key={item.name}
                     href={item.href}
@@ -163,7 +399,8 @@ function Layout({ children }) {
                   >
                     {item.name}
                   </a>
-                ))}
+                  )
+                })}
                 <Button
                   asChild
                   className="mt-4 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white"


### PR DESCRIPTION
Closes #298. Refs #283.

## Summary

Replaces the single `/never-hungover` nav link with a "Topics" mega-menu dropdown exposing all 6 cluster pillars defined in `scripts/cluster-config.json`. Each cluster section shows the pillar post link plus 5 top spokes (auto-derived from `cluster.spokes`). Adding/modifying a cluster in `cluster-config.json` updates the nav with zero code changes.

T4 audit found NO blog posts in primary nav — all 189 hidden behind `/never-hungover` hub. Mega-menu surfaces 6 pillars × 5 spokes = 30 high-value posts directly in primary nav. Expected uplift: +3-5% blog traffic from broader internal-link reach (synthesis-S3 Intervention 5).

## Nav structure

- DHM Master → DHM Dosage Guide + 5 spokes (science, safety, stack, timing, daily use)
- Liver Health → Advanced Liver Detox + 5 spokes (fatty liver, diet, methods, complete guide, alcohol)
- Alcohol & Health → Alcohol Aging & Longevity + 5 spokes (cognitive, heart, immune, inflammation, bone)
- Alcohol Science → Pharmacokinetics + 5 spokes (genetics, altitude, athletes, metabolic flex, REM)
- Hangover Prevention → Functional Medicine Hangover + 5 spokes (supplements, GMHP, charcoal, headache, nausea)
- Product Reviews → Double Wood vs No Days Wasted + 5 spokes (DW review, NDW review, Flyby vs DW, Flyby, DW vs Fuller)

## Behavior

- **Desktop**: hover or keyboard focus opens 3-col grid panel below nav. Mouse-leave / Escape / outside-click closes.
- **Mobile**: collapsible "Topics" header nested in existing hamburger menu. Tap to expand all 6 cluster sections inline.
- **Tracking**: `data-track="nav-topics-trigger|cluster|spoke"` + `data-cluster` on every link.
- **A11y**: `aria-haspopup`, `aria-expanded`, `aria-controls`, escape-to-close, outside-click handler, focus-on-button-also-opens.

## Files changed

- `src/components/layout/Layout.jsx` — added imports, state, util fns, replaced /never-hungover render in both desktop+mobile paths
- `specs/issue-298-mega-menu/{research,design,tasks,plan}.md`

## Test plan

- [x] `npm run build` passes (189 blog posts + 7 main pages prerendered)
- [x] JS bundle contains "Topics" string + all 6 pillar slugs
- [ ] Desktop: hover Topics → panel opens with 6 clusters × 5 spokes
- [ ] Desktop: Escape closes panel
- [ ] Mobile: hamburger → Topics → tap expands cluster sections
- [ ] Pillar links navigate to /never-hungover/{pillar-slug}
- [ ] Spoke links navigate to /never-hungover/{spoke-slug}
- [ ] Other nav items (Reviews, Compare, Guide, etc.) unchanged
- [ ] Active-tab indicator preserved when on /never-hungover routes