### PR TITLE
fix: regenerate pnpm-lock.yaml after micromark dep adds (UNBLOCK Vercel deploys)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,12 @@ importers:
       lucide-react:
         specifier: ^0.510.0
         version: 0.510.0(react@19.1.0)
+      micromark:
+        specifier: ^4.0.2
+        version: 4.0.2
+      micromark-extension-gfm:
+        specifier: ^3.0.0
+        version: 3.0.0
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
🚨 **Hotfix**: Vercel deploys have been failing since PR #310 (cloaking fix) due to ERR_PNPM_OUTDATED_LOCKFILE.

`micromark` + `micromark-extension-gfm` were added via `npm install` which only updates `package-lock.json`. Vercel runs `pnpm install --frozen-lockfile` and rejected the build because `pnpm-lock.yaml` didn't match `package.json`.

**Result**: ~18 PRs merged today never deployed. Site stuck on pre-#310 build.

**Fix**: ran `pnpm install` locally to regenerate the lockfile.

After this merges, the next Vercel deploy will catch up all queued changes in one cumulative deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)