### PR TITLE
chore: add CI gate to catch lockfile drift before merge

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.4.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -28,8 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.4.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -1,0 +1,40 @@
+name: Lockfile check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  pnpm-frozen-lockfile:
+    name: Verify pnpm-lock.yaml is in sync with package.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
+
+  build:
+    name: Build smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/lockfile-check.yml`) that runs on every PR to `main` and blocks merge if the lockfile drifts from `package.json`.

Two jobs:
1. **pnpm-frozen-lockfile** — runs `pnpm install --frozen-lockfile`. This is the exact command Vercel uses in CI, so anything that passes here will install on Vercel.
2. **build** — runs `pnpm install --frozen-lockfile && pnpm run build` to also catch other build breakage (validate-posts, prerender, vite build).

Pinned `pnpm@10.4.1` (matches `packageManager` field in `package.json`) and Node 22.

## Motivation — today's incident

PR #310 (merged 11:54 UTC) added two direct dependencies (`micromark`, `micromark-extension-gfm`) to `package.json` without regenerating `pnpm-lock.yaml`. Vercel's CI defaults to `pnpm install --frozen-lockfile`, so 12+ consecutive Vercel deploys errored within ~10 seconds with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml
is not up to date with <ROOT>/package.json
```

Production was stuck on a 4-hour-old build for ~2 hours until PR #328 (`762b572`) regenerated the lockfile.

Full post-mortem: `docs/deploy-investigation-2026-04-26/v1-deploy-state.md`

With this gate in place, PR #310 would have failed CI and never merged — production would have stayed healthy.

## What it catches

- Adding/upgrading/removing a dep without running `pnpm install` locally
- Hand-edits to `package.json` that don't update the lockfile
- Stale `pnpm-lock.yaml` from rebases/merges
- Build script regressions (validate-posts, prerender, vite build)

## What it doesn't do

- Doesn't auto-fix the lockfile (intentional — fix locally and push)
- Doesn't run on `push` to `main` (the merge itself is gated, that's enough)
- Doesn't run tests, lint, or typecheck (out of scope; can add later if needed)

## Performance

- Lockfile check job: ~30 sec (mostly pnpm install with cache)
- Build job: ~60–90 sec (build is fast; node_modules cached via `setup-node` `cache: pnpm`)
- Both jobs run in parallel, so total wall time ~90 sec

## Test plan

- [ ] After merge, the workflow becomes active for all future PRs to main
- [ ] (Optional) Push a test branch with a deliberately edited `package.json` (no lockfile update) and confirm the action fails with `ERR_PNPM_OUTDATED_LOCKFILE`