### PR TITLE
fix: portal mega-menu dropdown to document.body to escape header stacking context

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { Button } from '@/components/ui/button.jsx'
 import { Menu, X, Leaf, ChevronDown } from 'lucide-react'
@@ -38,16 +39,29 @@ function Layout({ children }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isTopicsOpen, setIsTopicsOpen] = useState(false)
   const [expandedClusterMobile, setExpandedClusterMobile] = useState(null)
+  // Mount flag — createPortal needs document.body, which doesn't exist
+  // on the server during SSR / prerender. Render dropdown only after mount.
+  const [mounted, setMounted] = useState(false)
   const topicsRef = useRef(null)
+  const dropdownRef = useRef(null)
   const { currentPath, navigate, isActive, getNavItems, getFooterItems } = useRouter()
   const { headerRef, headerHeight } = useHeaderHeight()
 
-  // Close topics dropdown on Escape or outside click
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Close topics dropdown on Escape or outside click.
+  // Outside-click must check BOTH the trigger (topicsRef) and the portaled
+  // dropdown (dropdownRef) — the dropdown lives in document.body now, so
+  // it's not a descendant of the trigger anymore.
   useEffect(() => {
     if (!isTopicsOpen) return
     const onKey = (e) => { if (e.key === 'Escape') setIsTopicsOpen(false) }
     const onClick = (e) => {
-      if (topicsRef.current && !topicsRef.current.contains(e.target)) {
+      const inTrigger = topicsRef.current && topicsRef.current.contains(e.target)
+      const inDropdown = dropdownRef.current && dropdownRef.current.contains(e.target)
+      if (!inTrigger && !inDropdown) {
         setIsTopicsOpen(false)
       }
     }
@@ -155,81 +169,11 @@ function Layout({ children }) {
                           />
                         )}
                       </button>
-                      {isTopicsOpen && (
-                        <div
-                          id="topics-mega-menu"
-                          role="region"
-                          aria-label="Topics"
-                          // position:fixed escapes any ancestor stacking context
-                          // (defense in depth — the header's stacking context was
-                          // the original cause of the overlap bug; using fixed makes
-                          // the dropdown immune to any future ancestor that creates
-                          // one — opacity, transform, filter, will-change, etc.)
-                          style={{ top: headerHeight + 8 }}
-                          className="fixed left-1/2 -translate-x-1/2 w-screen max-w-4xl bg-white rounded-xl shadow-2xl border border-gray-100 p-6 z-50"
-                        >
-                          <div className="grid grid-cols-3 gap-x-6 gap-y-5">
-                            {clusterConfig.clusters.map((cluster) => {
-                              const pillarHref = `/never-hungover/${cluster.pillar}`
-                              return (
-                                <div key={cluster.name}>
-                                  <a
-                                    href={pillarHref}
-                                    onClick={(e) => {
-                                      if (e.metaKey || e.ctrlKey) return
-                                      e.preventDefault()
-                                      setIsTopicsOpen(false)
-                                      handleNavigation(pillarHref)
-                                    }}
-                                    data-track="nav-topics-cluster"
-                                    data-cluster={cluster.name}
-                                    className="block text-sm font-bold text-green-700 hover:text-green-900 mb-2 leading-tight"
-                                  >
-                                    {clusterLabel(cluster.name)} →
-                                  </a>
-                                  <ul className="space-y-1.5">
-                                    {cluster.spokes.slice(0, SPOKES_PER_CLUSTER).map((spoke) => {
-                                      const href = `/never-hungover/${spoke}`
-                                      return (
-                                        <li key={spoke}>
-                                          <a
-                                            href={href}
-                                            onClick={(e) => {
-                                              if (e.metaKey || e.ctrlKey) return
-                                              e.preventDefault()
-                                              setIsTopicsOpen(false)
-                                              handleNavigation(href)
-                                            }}
-                                            data-track="nav-topics-spoke"
-                                            data-cluster={cluster.name}
-                                            className="block text-xs text-gray-600 hover:text-green-600 leading-snug"
-                                          >
-                                            {slugToSpokeTitle(spoke)}
-                                          </a>
-                                        </li>
-                                      )
-                                    })}
-                                  </ul>
-                                </div>
-                              )
-                            })}
-                          </div>
-                          <div className="mt-5 pt-4 border-t border-gray-100">
-                            <a
-                              href="/never-hungover"
-                              onClick={(e) => {
-                                if (e.metaKey || e.ctrlKey) return
-                                e.preventDefault()
-                                setIsTopicsOpen(false)
-                                handleNavigation('/never-hungover')
-                              }}
-                              className="text-sm font-medium text-green-600 hover:text-green-800"
-                            >
-                              View all articles →
-                            </a>
-                          </div>
-                        </div>
-                      )}
+                      {/* Dropdown panel is portaled to document.body — see below.
+                          This breaks it out of the header's DOM subtree (and any
+                          stacking context the header creates from backdrop-filter,
+                          opacity, transform, etc.). The trigger button stays here
+                          inside the header for accessibility & layout. */}
                     </div>
                   )
                 }
@@ -431,6 +375,91 @@ function Layout({ children }) {
           )}
         </div>
       </header>
+
+      {/* Topics mega-menu dropdown — portaled to document.body so it escapes
+          the header's stacking context entirely. The header has position:fixed
+          + backdrop-filter (and possibly future transforms/filters), each of
+          which create a stacking context that traps z-index of descendants.
+          By rendering into document.body, the dropdown sits at the document
+          root's stacking context where its z-50 stacks above all page chrome.
+          Hover semantics are preserved by adding onMouseEnter/onMouseLeave
+          here that flip the same isTopicsOpen state — so cursor moving from
+          trigger → dropdown keeps it open even though they're no longer
+          parent/child in the DOM tree. */}
+      {mounted && isTopicsOpen && createPortal(
+        <div
+          ref={dropdownRef}
+          id="topics-mega-menu"
+          role="region"
+          aria-label="Topics"
+          onMouseEnter={() => setIsTopicsOpen(true)}
+          onMouseLeave={() => setIsTopicsOpen(false)}
+          style={{ top: headerHeight + 8 }}
+          className="fixed left-1/2 -translate-x-1/2 w-screen max-w-4xl bg-white rounded-xl shadow-2xl border border-gray-100 p-6 z-50"
+        >
+          <div className="grid grid-cols-3 gap-x-6 gap-y-5">
+            {clusterConfig.clusters.map((cluster) => {
+              const pillarHref = `/never-hungover/${cluster.pillar}`
+              return (
+                <div key={cluster.name}>
+                  <a
+                    href={pillarHref}
+                    onClick={(e) => {
+                      if (e.metaKey || e.ctrlKey) return
+                      e.preventDefault()
+                      setIsTopicsOpen(false)
+                      handleNavigation(pillarHref)
+                    }}
+                    data-track="nav-topics-cluster"
+                    data-cluster={cluster.name}
+                    className="block text-sm font-bold text-green-700 hover:text-green-900 mb-2 leading-tight"
+                  >
+                    {clusterLabel(cluster.name)} →
+                  </a>
+                  <ul className="space-y-1.5">
+                    {cluster.spokes.slice(0, SPOKES_PER_CLUSTER).map((spoke) => {
+                      const href = `/never-hungover/${spoke}`
+                      return (
+                        <li key={spoke}>
+                          <a
+                            href={href}
+                            onClick={(e) => {
+                              if (e.metaKey || e.ctrlKey) return
+                              e.preventDefault()
+                              setIsTopicsOpen(false)
+                              handleNavigation(href)
+                            }}
+                            data-track="nav-topics-spoke"
+                            data-cluster={cluster.name}
+                            className="block text-xs text-gray-600 hover:text-green-600 leading-snug"
+                          >
+                            {slugToSpokeTitle(spoke)}
+                          </a>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              )
+            })}
+          </div>
+          <div className="mt-5 pt-4 border-t border-gray-100">
+            <a
+              href="/never-hungover"
+              onClick={(e) => {
+                if (e.metaKey || e.ctrlKey) return
+                e.preventDefault()
+                setIsTopicsOpen(false)
+                handleNavigation('/never-hungover')
+              }}
+              className="text-sm font-medium text-green-600 hover:text-green-800"
+            >
+              View all articles →
+            </a>
+          </div>
+        </div>,
+        document.body
+      )}
 
       {/* Main Content */}
       <main style={{ paddingTop: `${headerHeight}px` }} className="transition-[padding] duration-300">


### PR DESCRIPTION
## Bug
PR #339 partially fixed the mega-menu overlap bug by removing the opacity animation that was creating the header's stacking context. **The bug persists in production** because the header still creates a stacking context via:
- `position: fixed` with `z-index`
- `backdrop-filter: blur(12px)` (per CSS spec, creates a stacking context)

Either of these is sufficient to trap a descendant's `z-index`. The Topics dropdown — even though it's `position: fixed` with `z-50` — is a DOM descendant of the header, so its `z-50` resolves *inside* the header's local stacking context. Page content (hero images, comparison tables, anything with `z-index >= 1`) lives in the document root context and paints above the dropdown.

## Fix: createPortal escape hatch

`createPortal(<dropdown />, document.body)` renders the dropdown directly into `document.body`. This breaks it out of the header's DOM subtree entirely, placing it at the **document root's stacking context** where its `z-50` stacks above all page chrome regardless of what stacking contexts ancestors create — present or future (transforms, filters, will-change, etc.).

## Changes (single file: `src/components/layout/Layout.jsx`)

- Import `createPortal` from `react-dom`
- Add `mounted` state + `useEffect` to gate portal until client mount (`document.body` doesn't exist during SSR/prerender)
- Add `dropdownRef` for outside-click detection
- Move dropdown JSX out of the header subtree; wrap in `createPortal(..., document.body)`
- Outside-click handler now checks BOTH `topicsRef` (trigger) and `dropdownRef` (portaled panel) — the panel is no longer a descendant of the trigger
- Add `onMouseEnter`/`onMouseLeave` to the portaled dropdown so cursor moving from trigger → dropdown keeps it open (preserves hover semantics across the DOM gap created by portaling)
- Preserved all aria attributes, focus management, Escape-key handler, click handlers, A/B tracking attributes

## Why portal vs. other approaches

- ❌ Bumping `z-50` to `z-[100]` — z-index is meaningless across stacking contexts
- ❌ Adding `isolation: isolate` to `<main>` — header's context still traps the dropdown
- ❌ Removing `backdrop-filter` from header — visible visual regression (loses frosted glass look)
- ✅ **Portal** — completely escapes any present or future stacking context the header might create

## Verification

- `npm run build` passes (197 prerendered posts + 7 main pages)
- Dropdown markup absent from prerendered HTML (correct — it's React-rendered client-side, conditional on `isTopicsOpen`)
- Bundle includes the portaled JSX (`grep "topics-mega-menu" dist/assets/index-*.js` matches)

## Audit artifacts

- `docs/layering-audit-2026-04-26/L1-zindex-inventory.md` — z-index census
- `docs/layering-audit-2026-04-26/L2-stacking-contexts.md` — stacking context creators
- `docs/layering-audit-2026-04-26/L4-component-audit.md` — component-level audit
- `docs/layering-audit-2026-04-26/L5-remediation-plan.md` — remediation plan

## Related
- Follows up #339 (which was insufficient — opacity removal alone didn't fix the trap because backdrop-filter still creates a stacking context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)