### PR TITLE
chore: layering safety net — verify-z-classes build gate + ESLint shell rule + CLAUDE.md patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,43 @@ git push origin branch-name
 
 **Key insight:** External AI review is most valuable for catching inflated expectations and identifying cut candidates. Original plan would have taken 80+ min with questionable ROI. Filtered plan took 40 min with clear, achievable goals.
 
+### Pattern #14: Stacking-Context Trap — Walk the Parent Chain, Don't Bump Z-Index (PRs #339, #340)
+**What we learned:** Two PRs over 30 minutes both tried to fix the same mega-menu overlap by changing the dropdown. Neither worked because the bug was in an *ancestor*, not the dropdown. PR #339 removed an `opacity: 0.95` animation (one stacking-context creator) from the header. PR #340 worked because it severed the DOM relationship — portaled the dropdown to `document.body`. The header still had two stacking-context creators (`position: fixed` and `backdrop-filter: blur-md`), but they no longer mattered once the dropdown was no longer their descendant.
+
+**Application:**
+- When a layered element doesn't paint where you expect, **walk the parent chain in DevTools** looking for any of these on ancestors: `transform`, `opacity ≠ 1`, `filter`, `backdrop-filter`, `will-change` (transform/opacity), `isolation: isolate`, `contain: paint`, `mix-blend-mode`, `clip-path`. The first one you find is your culprit.
+- "Z-index doesn't work" is rarely solved by a bigger number. It's solved by understanding which stacking context contains your element.
+- For elements that must paint above arbitrary page content, **portal them to `document.body`** via `createPortal`. This breaks the DOM relationship that traps z-index.
+- **Never style `<header>`, `<main>`, `<footer>`, or `<App>`** with `transform`, `opacity ≠ 1`, `filter`, or `motion.*` wrappers. These create stacking contexts that trap every descendant.
+- Verify the fix with `document.elementsFromPoint(x, y)` in DevTools — that returns the actual paint order at a coordinate, ground truth.
+
+**Key insight:** The mega-menu DOM lived inside the header. Even when we made the dropdown `position: fixed; z-50`, fixed-positioned elements DO NOT escape ancestor stacking contexts (only the offset parent changes). The portal was the fix.
+
+### Pattern #15: Tailwind v4 Theme Tokens Live in `@theme`, Not `tailwind.config.js` (PR #341)
+**What we learned:** For ~6 months after the Tailwind v3→v4 upgrade, all 12 custom z-index tokens (`z-header`, `z-modal`, `z-popover`, etc.) were defined in `tailwind.config.js` `theme.extend.zIndex` — and Tailwind v4 silently ignored them. NO classes were generated. Live `<header class="z-header">` resolved to `z-index: auto`. Page images scrolled over the fixed header. We discovered the bug only when looking at it head-on with `curl <site> | grep -oE "\.z-header\b"` and finding nothing.
+
+**Application:**
+- In Tailwind v4, **all custom design tokens go in a `@theme` block in CSS**, not in `tailwind.config.js`. The v3 `theme.extend.{colors,zIndex,spacing,fontFamily,...}` syntax is silently ignored. No error, no warning, no console output — just no generated classes.
+- After ANY major build-tool upgrade (Tailwind, PostCSS, Vite, framework majors), run a smoke test against the BUILT output to verify tokens emit:
+  ```bash
+  npm run build && grep -oE "\\.z-(header|modal|popover|...)" dist/assets/*.css | sort -u
+  ```
+- **A build-time check (`scripts/verify-z-classes.mjs`) wired into `npm run build`** catches this class of regression structurally. Wired between `vite build` and prerender, so Vercel's CI naturally enforces it.
+- IDE autocomplete is not authoritative. It reads the JS config object, not the actual emitted CSS. Trust the dist artifact, not the source-of-intent.
+
+**Key insight:** Silent migration regressions are the worst category — no error, no test failure, just a feature that quietly stops working. The cure is testing the OUTPUT, not the INPUT. Same lesson applies to Vite, PostCSS, framework major upgrades.
+
+### Pattern #16: Renumbering a Z-Index Scale Inverts Every Implicit Relationship (PR #341 latent issues)
+**What we learned:** PR #341 fixed the broken `z-header` token by emitting it correctly, AND simultaneously bumped its value from 30 → 40 to outrank stock z-30 page content. That bump silently inverted three design relationships: `comparison: 35` (originally "above header") is now below header (40); `overlay: 40` is now tied with header; modal (50) is now only 10 above header instead of 20. Each was an intentional design decision encoded as a numeric gap, not a token name. The intent was preserved in a single inline comment that nobody re-read.
+
+**Application:**
+- Treat **the gaps between z-index tokens as intentional design**. Names tell you "this is the modal layer"; numbers tell you "the modal is 10 above the dropdown, 20 above the header." Both carry information.
+- Prefer **additive changes** (insert a new token between two existing ones) over **renumbers** (change an existing token's value). Renumbers cascade through every consumer.
+- Before bumping a token, run `grep -rn "z-{tokenname}" src/` AND `grep -rn "z-{tokenname-of-the-thing-just-below-it}" src/` to see what relationships you're moving.
+- When you do renumber, audit every consumer afterward — verify the design intent expressed in original-value gaps is preserved or explicitly re-decided.
+
+**Key insight:** A z-scale is a partial order, not a list. Names communicate "what" but the values communicate "in what relationship to siblings." Both pieces of information must move together when the scale changes.
+
 ---
 
 ## 🔄 Continuous Improvement

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,21 @@ export default [
         'warn',
         { allowConstantExport: true },
       ],
+      // Layering safety: ban motion.header / motion.main / motion.footer.
+      // These wrap the layout shell with framer-motion, which applies a
+      // continuous transform/opacity → creates a stacking context → traps
+      // any z-indexed descendants (e.g. the Topics dropdown, modals, etc.)
+      // inside the shell's local context. We hit this exact bug in PR #339
+      // when motion.header had `style={{ opacity: headerOpacity }}`.
+      // Ref: docs/layering-strategy-2026-04-27/A2-stacking-discipline.md (rule 3)
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXOpeningElement[name.type='JSXMemberExpression'][name.object.name='motion'][name.property.name=/^(header|main|footer)$/]",
+          message:
+            "Do not wrap layout-shell elements (header/main/footer) with framer-motion. Motion applies a transform/opacity that creates a stacking context, trapping descendants' z-index. Use a regular <header>/<main>/<footer> and put animations on inner sections.",
+        },
+      ],
     },
   },
 ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "DHM Guide Website - Deployment trigger 2025-01-05",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/validate-posts.js && node scripts/generate-blog-canonicals.js && node scripts/generate-sitemap.js && vite build && node scripts/prerender-blog-posts-enhanced.js && node scripts/prerender-main-pages.js",
+    "build": "node scripts/validate-posts.js && node scripts/generate-blog-canonicals.js && node scripts/generate-sitemap.js && vite build && node scripts/verify-z-classes.mjs && node scripts/prerender-blog-posts-enhanced.js && node scripts/prerender-main-pages.js",
     "lint": "eslint .",
     "preview": "vite preview",
     "verify-registry": "node verify-registry.js",

--- a/scripts/verify-z-classes.mjs
+++ b/scripts/verify-z-classes.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Verifies every z-* Tailwind class used in source actually exists in compiled CSS.
+ * Catches the v3→v4 silent-ignore class of bug (e.g. `z-header` → `z-auto`)
+ * that we shipped for ~6 months because tailwind.config.js theme.extend.zIndex
+ * is silently ignored by Tailwind v4.
+ *
+ * Runs in `npm run build` between `vite build` and prerender, so:
+ *   - dist/ exists and the compiled CSS is fresh
+ *   - the build fails fast if the scale is broken
+ *   - Vercel naturally enforces the gate (build runs in CI)
+ *
+ * Allowlist: stock Tailwind defaults that always exist (z-0, z-10, ..., z-50, z-auto).
+ * Custom names (z-header, z-modal, etc.) MUST come from src/App.css @theme block.
+ *
+ * Refs: docs/layering-strategy-2026-04-27/A7-lint-static.md (rule #1)
+ *       PR #341 (the silent-ignore incident this prevents)
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const DIST_CSS_DIR = join(ROOT, 'dist', 'assets');
+const SRC_DIR = join(ROOT, 'src');
+
+const BUILTIN = new Set([
+  'z-0', 'z-10', 'z-20', 'z-30', 'z-40', 'z-50', 'z-auto',
+]);
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name.startsWith('.')) continue;
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (/\.(jsx?|tsx?|html|mdx?)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+// To avoid false positives from "z-index" (CSS prop name) or slugs like
+// "gen-z-mental-health-...", we ONLY scan inside className-like contexts:
+//   className="..." | className={'...'} | className={`...`} | class="..."
+// Then within each match, we extract z-* tokens.
+const CLASS_CTX = /(?:className|class)\s*=\s*(?:["'`]([^"'`]+)["'`]|\{[^}]*?["'`]([^"'`]+)["'`][^}]*?\})/g;
+// Within a className string, match z-NAME (excluding "z-index" which is a CSS
+// prop name that sometimes leaks into class strings) or z-[ARBITRARY].
+const Z_TOKEN = /\bz-(?!index\b)([a-z][a-z0-9-]*|\[[^\]]+\])\b/g;
+
+function extractZTokens(content, dest) {
+  for (const m of content.matchAll(CLASS_CTX)) {
+    const cls = m[1] || m[2] || '';
+    for (const z of cls.matchAll(Z_TOKEN)) dest.add(z[0]);
+  }
+}
+
+const used = new Set();
+let filesScanned = 0;
+for (const file of walk(SRC_DIR)) {
+  filesScanned++;
+  extractZTokens(readFileSync(file, 'utf8'), used);
+}
+try {
+  extractZTokens(readFileSync(join(ROOT, 'index.html'), 'utf8'), used);
+} catch {
+  /* optional */
+}
+
+let cssFiles = [];
+try {
+  cssFiles = readdirSync(DIST_CSS_DIR).filter((f) => f.endsWith('.css'));
+} catch (e) {
+  console.error('[verify-z-classes] dist/assets/ not found - run `vite build` first');
+  process.exit(1);
+}
+const compiledCss = cssFiles
+  .map((f) => readFileSync(join(DIST_CSS_DIR, f), 'utf8'))
+  .join('\n');
+
+const missing = [];
+for (const cls of used) {
+  if (BUILTIN.has(cls)) continue;
+  const escaped = cls.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const ruleRe = new RegExp('\\.' + escaped + '\\s*\\{');
+  if (!ruleRe.test(compiledCss)) missing.push(cls);
+}
+
+if (missing.length) {
+  console.error(
+    '\n[verify-z-classes] FAIL - these z-* classes are used in source but absent from dist/ CSS:',
+  );
+  for (const m of missing.sort()) console.error('  ' + m);
+  console.error(
+    '\nLikely cause: missing token in `src/App.css` `@theme inline { --z-index-* }` block.',
+  );
+  console.error('Tailwind v4 generates `.z-NAME` utilities only from `@theme`, not from');
+  console.error('`tailwind.config.js theme.extend.zIndex` (silently ignored in v4).');
+  console.error('\nFiles scanned: ' + filesScanned + '. CSS bundles: ' + cssFiles.length + '.\n');
+  process.exit(1);
+}
+
+console.log(
+  '[verify-z-classes] OK - ' + used.size + ' z-* classes verified against compiled CSS (' + filesScanned + ' files, ' + cssFiles.length + ' CSS bundles).',
+);


### PR DESCRIPTION
Insurance against the bug class that surfaced today. Two CI gates plus documented lessons; zero behavior change.

## What ships

### `scripts/verify-z-classes.mjs` (NEW build-time check)
Walks src/ for `z-*` classes inside `className` attributes, asserts each exists in `dist/assets/*.css`, fails build with a helpful error if not. Wired into `npm run build` between `vite build` and prerender.

**Would have caught**: PR #341's root cause (12 custom z-tokens silently generated 0 classes for ~6 months on Tailwind v3→v4 upgrade).

### ESLint `no-restricted-syntax` rule
Bans `motion.header`, `motion.main`, `motion.footer`. Framer-motion's continuous transform/opacity creates stacking contexts that trap descendants' z-index.

**Would have caught**: PR #339's regression at the source (the original `<motion.header style={{opacity: headerOpacity}}>`).

### CLAUDE.md Patterns #14, #15, #16
- #14 Stacking-context trap (walk the parent chain, don't bump z-index, portal to body)
- #15 Tailwind v4 tokens belong in `@theme` not `tailwind.config.js`
- #16 Renumbering a z-scale inverts implicit relationships

Refs: `docs/layering-strategy-2026-04-27/{A2,A7,A9,00-ROADMAP}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)