### PR TITLE
fix: restore off-screen positioning on prerender div (eliminate FOUC)

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,9 +235,11 @@
   <body>
     <div id="root">
       <!-- Initial content for crawlers while React loads.
-           Issue #284: removed off-screen positioning (cloaking pattern).
-           React's createRoot replaces this on mount; visible briefly is fine. -->
-      <div>
+           Off-screen positioned so real users don't see the unstyled flash
+           before React mounts (FOUC). Crawlers (Twitter, FB, LinkedIn, Bing)
+           parse raw HTML and ignore positioning. Content is identical to
+           what React renders, so this is not cloaking. -->
+      <div style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
         <h1>DHM Guide: Science-Backed Hangover Prevention</h1>
         <p>Discover how DHM (Dihydromyricetin) prevents hangovers with clinically-proven effectiveness. Based on 11+ scientific studies and UCLA research.</p>
         <p>Learn about proper DHM dosage, timing, and the best supplements for hangover prevention.</p>

--- a/scripts/prerender-blog-posts-enhanced.js
+++ b/scripts/prerender-blog-posts-enhanced.js
@@ -325,7 +325,7 @@ async function prerenderPost(post, baseHtml, blogDistDir) {
       : '';
 
     rootDiv.innerHTML = `
-      <div id="prerender-content">
+      <div id="prerender-content" style="position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden;">
         <article>
           <h1>${safeTitle}</h1>
           <div class="meta">


### PR DESCRIPTION
## Summary
- Restores off-screen positioning on the SPA fallback stub in `index.html` and on the per-post prerender div in `scripts/prerender-blog-posts-enhanced.js`.
- Reverts the visibility-only change from PR #310 (commit faf58a7); keeps PR #310's full-article-content fix intact.
- Eliminates the ~200-400ms flash of unstyled prerendered HTML that real users see before React mounts.

## Root cause
PR #310 fixed two things at once: (a) made prerender emit FULL article HTML (instead of a 100-word stub), and (b) removed the off-screen positioning. The first fix was correct and remains. The second exposed the prerendered raw HTML to real users, creating the FOUC.

`createRoot()` in `src/main.jsx:139` wipes the prerendered DOM on mount, so users see: bare HTML in browser-default fonts → blank moment → styled React article. With off-screen positioning back, only crawlers see the prerendered HTML; real users see: blank → styled React article (normal).

## Why this isn't cloaking
Google's cloaking policy targets content that DIFFERS between crawlers and users. Here both see identical content (same article from same JSON source). The prerender is a layout choice, not a content substitution.

## Test plan
- [x] `npm run build` succeeds — 197 posts + 7 main pages prerendered
- [x] `grep "left: -9999px" dist/index.html` → present
- [x] `grep "left: -9999px" dist/never-hungover/dhm-dosage-guide-2025/index.html` → present
- [x] `dhm-dosage-guide-2025` prerendered HTML still has 100+ `<p>` tags (crawlers see full content)
- [ ] Vercel preview deploys, open a blog post on slow 3G throttle in Chrome DevTools — verify no raw-text flash before React mounts
- [ ] Spot-check Twitter card preview via https://cards-dev.twitter.com/validator on a deploy preview URL — verify post-specific OG tags still parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)