### PR TITLE
fix(seo): trim DHM Clinical Trials title to under 60 chars (#143)

### DIFF
--- a/specs/issue-143-clinical-trials-title/tasks.md
+++ b/specs/issue-143-clinical-trials-title/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — Issue #143
+
+## Task 1: Trim DHM Clinical Trials title from 68 → 55 chars
+
+**File**: `src/newblog/data/posts/dhm-randomized-controlled-trials.json`
+
+**Edit**: Replace line 3
+```diff
+-  "title": "DHM Clinical Trials 2026: The Science Behind 70% Hangover Prevention",
++  "title": "DHM Clinical Trials 2026: 70% Hangover Reduction Proven",
+```
+
+**Verify steps**:
+1. `npm run build` returns exit 0
+2. `grep -oE '<title>[^<]+' dist/never-hungover/dhm-randomized-controlled-trials/index.html` includes the new 55-char title
+3. JSON still parses (build will fail if not)
+4. No unrelated files staged in commit
+
+**Status**: complete (single-edit task)

--- a/src/newblog/data/posts/dhm-randomized-controlled-trials.json
+++ b/src/newblog/data/posts/dhm-randomized-controlled-trials.json
@@ -1,6 +1,6 @@
 {
   "id": "dhm-randomized-controlled-trials",
-  "title": "DHM Clinical Trials 2026: The Science Behind 70% Hangover Prevention",
+  "title": "DHM Clinical Trials 2026: 70% Hangover Reduction Proven",
   "slug": "dhm-randomized-controlled-trials",
   "excerpt": "Peer-reviewed clinical trial proves DHM reduces hangover severity by 70% (p<0.001). See the UCLA, USC, and Foods journal research that validates DHM's effectiveness.",
   "quickAnswer": "Peer-reviewed clinical trial proves DHM reduces hangover severity by 70% (p<0.001). See the UCLA, USC, and Foods journal research that validates DHM's effectiveness.",


### PR DESCRIPTION
Closes #143 (partial — title only; meta description deferred to follow-up #345)

- Title: \`DHM Clinical Trials 2026: 70% Hangover Reduction Proven\` (55 chars, was 68)
- File: \`src/newblog/data/posts/dhm-randomized-controlled-trials.json\`

Note: meta description rewrite portion of #143 ACs is shipped on #345 (residual cleanup PR — lands after this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)