### PR TITLE
fix(seo): trim NAC vs DHM title to 55 chars (#151)

### DIFF
--- a/specs/issue-151-nac-dhm-title/tasks.md
+++ b/specs/issue-151-nac-dhm-title/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — Issue #151
+
+## T-1: Trim NAC vs DHM `title` field (single string change)
+
+**File**: `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`
+
+**Edit**: replace line 2
+
+```diff
+-  "title": "NAC vs DHM: Which Antioxidant Works Better for Liver Protection? (2025)",
++  "title": "NAC vs DHM: Which Liver Supplement Works Better? [2025]",
+```
+
+**Verification**:
+1. `npm run build` exits 0.
+2. `grep -oE '<title>[^<]+' dist/never-hungover/nac-vs-dhm-which-antioxidant-better-liver-protection-2025/index.html` includes `NAC vs DHM: Which Liver Supplement Works Better? [2025]`.
+
+**Estimated effort**: 5 min (edit) + 90 sec (build + verify).
+
+## Commit plan
+
+1. `fix(seo): trim nac-vs-dhm title to under 60 chars (#151)` — JSON file only.
+2. `chore(spec): scaffold ralph spec artifacts for issue #151` — `specs/issue-151-nac-dhm-title/tasks.md` only (`.progress.md` and `.ralph-state.json` are gitignored).
+
+Both commits include `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.

--- a/src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json
+++ b/src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json
@@ -1,5 +1,5 @@
 {
-  "title": "NAC vs DHM: Which Antioxidant Works Better for Liver Protection? (2025)",
+  "title": "NAC vs DHM: Which Liver Supplement Works Better? [2025]",
   "slug": "nac-vs-dhm-which-antioxidant-better-liver-protection-2025",
   "excerpt": "Scientific comparison of NAC and DHM for liver protection. Learn the mechanisms, benefits, and optimal use cases for each antioxidant supplement.",
   "quickAnswer": "Scientific comparison of NAC and DHM for liver protection. Learn the mechanisms, benefits, and optimal use cases for each antioxidant supplement.",


### PR DESCRIPTION
Closes #151 (partial — title only; meta description deferred to #345)

- Title: \`NAC vs DHM: Which Liver Supplement Works Better? [2025]\` (55 chars, was 71)
- File: \`src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json\`

Used \`[2025]\` instead of issue's recommended \`[2025 Test]\` (avoids implying the page is itself a test). Meta description rewrite portion of #151 ACs is on #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)