### PR TITLE
Residual cleanup after April 2026 triage (#345 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,6 +572,22 @@ git push origin branch-name
 
 ---
 
+## Spec Artifact Commit Policy
+
+For each `specs/issue-*/` directory, commit:
+- `research.md`
+- `requirements.md`
+- `design.md`
+- `tasks.md`
+
+Do NOT commit:
+- `.progress.md` (gitignored — working notes that change frequently)
+- `.ralph-state.json` (gitignored — runtime state)
+
+This ensures spec history is reviewable in PR while runtime artifacts stay out of the diff.
+
+---
+
 ## ⚠️ Red Flags (STOP and Simplify)
 
 If you find yourself:

--- a/specs/issue-345-residual/design.md
+++ b/specs/issue-345-residual/design.md
@@ -1,0 +1,264 @@
+---
+spec: issue-345-residual
+phase: design
+created: 2026-04-28
+mode: quick
+---
+
+# Design: issue-345-residual
+
+## Overview
+
+Two file edits (A1 + A2) on post JSONs touching only the `metaDescription` field. One file edit (B1) appending a ~12-line "Spec Artifact Commit Policy" section to project `CLAUDE.md`. A3 + A4 redirected to `cleanup/issue-209-best-for-buttons` branch (target code does not exist on main) — documented in `tasks.md` per AC-9. Total diff: 2 single-field JSON edits + 1 markdown section + 1 spec note. No code logic, no dependencies, no `.gitignore` change.
+
+## Decisions Resolved
+
+### D1: Where to document the spec policy (B1)?
+
+| Option | Verdict | Rationale |
+|---|---|---|
+| **(a) Add ~12 lines to project `CLAUDE.md`** | **CHOSEN** | CLAUDE.md auto-loads every session — maximum discoverability. Single-file change. No new file to find. |
+| (b) Create `specs/.policy.md` | Rejected | Adds a file nobody would naturally open. Lower discoverability. |
+| (c) Document only in this spec's research.md | Rejected | Institutional-knowledge only — invisible to future contributors. |
+
+**Insertion location**: after `## 🔄 Continuous Improvement` (lines 559–573) and its trailing `---` divider, before `## ⚠️ Red Flags (STOP and Simplify)` (line 575). Natural fit because spec-hygiene is a workflow/process rule like Continuous Improvement, and pairing it before the "stop and simplify" rules reads coherently. Concretely: insert new `## Spec Artifact Commit Policy` section immediately after line 573.
+
+### D2: Verbatim meta-description text (verified against issues #143 + #151)
+
+**Issue #143** (`gh issue view 143 --jq .body`):
+- File: `src/newblog/data/posts/dhm-randomized-controlled-trials.json`
+- Current `metaDescription` (129 chars): `Peer-reviewed DHM clinical trials show 70% hangover reduction. UCLA and USC research explains exactly how DHM prevents hangovers.`
+- New `metaDescription` (149 chars, verbatim from issue): `Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works.`
+
+**Issue #151** (`gh issue view 151 --jq .body`):
+- File: `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`
+- Current `metaDescription` (138 chars): `NAC vs DHM for liver protection: NAC excels for daily support ($6-15/mo), DHM works best before drinking. Compare dosing, cost, and usage.`
+- New `metaDescription` (143 chars, verbatim from issue): `NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice).`
+
+Both new texts under the 160-char SERP truncation threshold (149 / 143). No trimming needed.
+
+### D3: CLAUDE.md insertion location (precise)
+
+CLAUDE.md current section order (line numbers):
+| Line | Section |
+|---|---|
+| 3 | 🧘 SIMPLICITY FIRST |
+| 27 | 🚀 COMPLETE DEVELOPMENT WORKFLOW |
+| 198 | 🛡️ SIMPLICITY ENFORCEMENT EXAMPLES |
+| 221 | 📁 DHM Guide Specific Context |
+| 279 | 🎯 Quick Command Reference |
+| 325 | 📋 Proven Patterns from Real Work |
+| 559 | 🔄 Continuous Improvement |
+| **575** | ⚠️ Red Flags (insertion point — new section goes ABOVE this) |
+| 590 | 📈 Success Metrics |
+
+**Concrete edit target**: line 573 (`---` divider following Continuous Improvement). Insert new `## Spec Artifact Commit Policy` section + trailing `---` divider between line 573 and line 575.
+
+## Architecture
+
+```mermaid
+graph LR
+    A[Issue #143 body] -->|verbatim metaDescription| B[dhm-randomized-controlled-trials.json]
+    C[Issue #151 body] -->|verbatim metaDescription| D[nac-vs-dhm-...json]
+    E[Spec policy] -->|new section ~12 lines| F[CLAUDE.md @ line 573]
+    G[A3+A4 redirect note] -->|AC-9 redirect doc| H[tasks.md]
+    B --> I[npm run build]
+    D --> I
+    I -->|prerender| J[dist HTML with new meta tags]
+```
+
+## File-by-File Plan
+
+### File 1: `src/newblog/data/posts/dhm-randomized-controlled-trials.json`
+
+| Aspect | Detail |
+|---|---|
+| Action | Modify single field |
+| Field | `metaDescription` |
+| Old text | `"Peer-reviewed DHM clinical trials show 70% hangover reduction. UCLA and USC research explains exactly how DHM prevents hangovers."` |
+| New text | `"Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works."` |
+| Char count | 129 → 149 |
+| All other fields | UNTOUCHED — especially `title` (which is owned by the `cleanup/issue-143-clinical-trials-title` branch) |
+| AC | AC-1, AC-2 |
+
+### File 2: `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`
+
+| Aspect | Detail |
+|---|---|
+| Action | Modify single field |
+| Field | `metaDescription` |
+| Old text | `"NAC vs DHM for liver protection: NAC excels for daily support ($6-15/mo), DHM works best before drinking. Compare dosing, cost, and usage."` |
+| New text | `"NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice)."` |
+| Char count | 138 → 143 |
+| All other fields | UNTOUCHED — especially `title` (owned by `cleanup/issue-151-nac-dhm-title`) |
+| AC | AC-3, AC-4 |
+
+### File 3: `CLAUDE.md`
+
+Insert after line 573 (the `---` divider following the "Continuous Improvement" section), before line 575 (the `## ⚠️ Red Flags` header). Final wording:
+
+```markdown
+## Spec Artifact Commit Policy
+
+For each `specs/issue-*/` directory, commit:
+- `research.md`
+- `requirements.md`
+- `design.md`
+- `tasks.md`
+
+Do NOT commit:
+- `.progress.md` (gitignored — working notes that change frequently)
+- `.ralph-state.json` (gitignored — runtime state)
+
+This ensures spec history is reviewable in PR while runtime artifacts stay out of the diff.
+
+---
+```
+
+Lines added: 14 (12 content lines + 1 trailing blank + 1 `---` divider). AC: AC-7, AC-8.
+
+### File 4: `specs/issue-345-residual/tasks.md`
+
+Document the A3+A4 redirect prominently. The PR body and tasks.md must both clearly state: "A3 (match-count badges) and A4 (regex expansion) redirected to `cleanup/issue-209-best-for-buttons` because the `bestForFilters` array does not exist on main." AC: AC-9.
+
+## Components
+
+### Component 1: JSON post-data edits (A1, A2)
+**Purpose**: rewrite SERP meta descriptions per GSC CTR optimization recommendations
+**Interfaces**:
+```typescript
+// post JSON shape (excerpt)
+interface BlogPost {
+  title: string;            // UNTOUCHED on this branch
+  metaDescription: string;  // CHANGED on this branch
+  // ... other fields untouched
+}
+```
+
+### Component 2: Documentation policy (B1)
+**Purpose**: codify spec-artifact commit convention so future contributors don't reverse-engineer it
+**Interface**: plain-text section in CLAUDE.md auto-loaded by Claude Code each session
+
+## Technical Decisions
+
+| Decision | Options | Choice | Rationale |
+|---|---|---|---|
+| Where to put spec policy | (a) CLAUDE.md, (b) specs/.policy.md, (c) research.md only | **(a)** | Auto-loaded each session, single file edit, max discoverability |
+| Insertion location in CLAUDE.md | After Continuous Improvement, after Proven Patterns, before Red Flags | **After Continuous Improvement (line 573)** | Process/workflow grouping; reads coherently before "stop and simplify" rules |
+| Field to edit on post JSONs | `metaDescription`, `seo.description`, `excerpt` | **`metaDescription` only** | Confirmed camelCase field; title owned by other branches; surgical scope |
+| A3/A4 disposition | (a) cherry-pick #209 here, (b) redirect to #209 branch | **(b) redirect** | `bestForFilters` doesn't exist on main; cherry-pick entangles branch state |
+| Verbatim text source | Re-write, paraphrase, or copy verbatim from issue body | **verbatim** | Issues #143/#151 are the canonical source; verbatim eliminates drift risk |
+
+## Verification Commands (for tasks.md `[VERIFY]` steps)
+
+```bash
+# AC-1, AC-3 — metaDescription updated and length under 160
+node -e "const p=JSON.parse(require('fs').readFileSync('src/newblog/data/posts/dhm-randomized-controlled-trials.json','utf8')); console.log(p.metaDescription.length, '|', p.metaDescription)"
+node -e "const p=JSON.parse(require('fs').readFileSync('src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json','utf8')); console.log(p.metaDescription.length, '|', p.metaDescription)"
+# Expected: "149 | Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works."
+# Expected: "143 | NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice)."
+
+# AC-2, AC-4 — title field UNTOUCHED (compare to main)
+git diff main..HEAD -- src/newblog/data/posts/dhm-randomized-controlled-trials.json | grep '"title":' || echo "title unchanged on this branch ✓"
+git diff main..HEAD -- src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json | grep '"title":' || echo "title unchanged on this branch ✓"
+
+# AC-5 — meta description present in prerendered HTML
+npm run build
+grep -oE 'name="description" content="[^"]*"' dist/never-hungover/dhm-randomized-controlled-trials/index.html | head -1
+grep -oE 'name="description" content="[^"]*"' dist/never-hungover/nac-vs-dhm-which-antioxidant-better-liver-protection-2025/index.html | head -1
+
+# AC-6 — build green
+echo $?  # expected: 0
+
+# AC-7, AC-8 — CLAUDE.md policy present
+grep -A 12 "## Spec Artifact Commit Policy" CLAUDE.md
+
+# AC-9 — A3/A4 redirect note in tasks.md
+grep -B1 -A3 "A3.*#209\|A4.*#209\|redirect.*209" specs/issue-345-residual/tasks.md
+```
+
+## Error Handling
+
+| Error Scenario | Handling | User Impact |
+|---|---|---|
+| Malformed JSON after edit | `validate-posts.js` (in `npm run build` chain) catches before deploy | Build fails fast; rollback via `git restore <file>` |
+| Wrong meta text (drift from issue) | Char-count assertion (149 / 143) confirms verbatim copy | Re-paste from issue body |
+| CLAUDE.md merge conflict with another branch | Unique section header `Spec Artifact Commit Policy` minimizes collision; manual resolve if needed | None expected — no live April 2026 branches edit CLAUDE.md |
+| Build error from prerender | Caught by `npm run build` exit code; AC-6 enforces zero | Investigate prerender script before merge |
+
+## Edge Cases
+
+- **Field name mismatch (`metaDescription` vs `seo.description`)**: confirmed in research — both target files use camelCase `metaDescription` at top level, no nested `seo` object.
+- **Char count over 160**: verified — 149 and 143, both under 160 with safety margin.
+- **#143/#151 branches haven't merged yet**: clean — title and metaDescription are different keys, layer cleanly via 3-way merge regardless of order.
+- **`---` divider preservation in CLAUDE.md**: insertion adds new content + new `---` after; existing `---` at line 573 remains as separator from Continuous Improvement.
+
+## Test Strategy
+
+| Type | Coverage |
+|---|---|
+| Build | `npm run build` must exit 0 (validates JSON, runs prerender, emits dist HTML) |
+| Output validation | `grep -oE 'name="description" content=...'` confirms new meta in prerendered HTML for both posts |
+| Field-level diff | `git diff main` confirms ONLY `metaDescription` changed on each post JSON |
+| Char count | Node one-liner asserts 149 / 143 |
+| Policy doc | `grep -A 12 "## Spec Artifact Commit Policy" CLAUDE.md` confirms presence |
+
+No unit tests exist for prerender/SEO content; the build chain itself is the test harness.
+
+## Risk + Rollback
+
+| Risk | Mitigation | Rollback |
+|---|---|---|
+| JSON corruption breaks build | `validate-posts.js` prebuild gate catches malformed JSON | `git restore src/newblog/data/posts/<file>.json` |
+| Wrong meta text shipped | Verbatim copy from issue body + char-count assertion | `git restore <file>.json` |
+| CLAUDE.md merge conflict | Unique section header minimizes collision; April 2026 audit confirms no other live branches edit CLAUDE.md | Manual conflict resolution; section is self-contained ~14 lines |
+| A3/A4 forgotten on #209 branch | AC-9 enforces explicit redirect note in tasks.md and PR body | Open follow-up issue if redirect dropped |
+
+## PR Strategy — Single PR with 4 Atomic Commits
+
+Each commit is scoped to a single concern, single file (or single artifact group). Commits are ordered for clean review.
+
+| # | Commit message | Files staged |
+|---|---|---|
+| 1 | `fix(seo): rewrite #143 meta description per issue acceptance criteria` | `src/newblog/data/posts/dhm-randomized-controlled-trials.json` only |
+| 2 | `fix(seo): rewrite #151 meta description per issue acceptance criteria` | `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` only |
+| 3 | `docs(claude): document spec artifact commit policy (#345 B1)` | `CLAUDE.md` only |
+| 4 | `chore(spec): scaffold ralph spec artifacts for issue #345` | `specs/issue-345-residual/{research,requirements,design,tasks}.md` (all 4 — practicing the new policy) |
+
+PR body must explicitly note A3+A4 redirect to `cleanup/issue-209-best-for-buttons` per AC-9.
+
+## Existing Patterns to Follow
+
+- **Pure data edits over code edits** (Pattern #6 in CLAUDE.md): both A1 and A2 are single-field JSON edits, lowest-risk class of change.
+- **Verbatim source quoting** (research phase rule): copy from issue bodies char-for-char to eliminate drift.
+- **Single source of truth for SEO** (Pattern #11): post JSONs are the canonical source; prerender + client-side both read from same JSON, no dual-source bug.
+- **Atomic single-purpose commits** (project git style): one concern per commit, easy review and rollback.
+- **CLAUDE.md as policy home** (existing convention): all simplicity rules, patterns, and workflow guidance already live here; spec-hygiene fits naturally.
+
+## File Structure Summary
+
+| File | Action | Lines | Purpose |
+|---|---|---|---|
+| `src/newblog/data/posts/dhm-randomized-controlled-trials.json` | Modify | 1 changed | A1: meta description rewrite |
+| `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` | Modify | 1 changed | A2: meta description rewrite |
+| `CLAUDE.md` | Modify | +14 inserted | B1: spec-artifact commit policy |
+| `specs/issue-345-residual/research.md` | Track (already exists) | — | Spec record |
+| `specs/issue-345-residual/requirements.md` | Track (already exists) | — | Spec record |
+| `specs/issue-345-residual/design.md` | Create (this file) | — | Spec record |
+| `specs/issue-345-residual/tasks.md` | Create (next phase) | — | Execution plan + AC-9 redirect note |
+
+**Total LOC delta**: ~16 lines (2 JSON field edits + 14 markdown lines).
+
+## Unresolved Questions
+
+None. All three decision points (D1, D2, D3) resolved above. Verbatim text confirmed against live issues. CLAUDE.md insertion line identified concretely.
+
+## Implementation Steps
+
+1. Edit `src/newblog/data/posts/dhm-randomized-controlled-trials.json` — replace `metaDescription` value with verbatim text from issue #143
+2. Edit `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` — replace `metaDescription` value with verbatim text from issue #151
+3. Edit `CLAUDE.md` — insert new `## Spec Artifact Commit Policy` section after line 573 (between Continuous Improvement and Red Flags)
+4. Run `npm run build` — verify exit 0, JSON valid, prerendered HTML contains new meta descriptions
+5. Run AC verification commands (above) — confirm AC-1 through AC-8 pass; AC-9 deferred to tasks.md
+6. Stage and commit per the 4-commit PR strategy (one file/concern per commit)
+7. Open PR referencing issues #143, #151, #251, #345; PR body must call out A3+A4 redirect to `cleanup/issue-209-best-for-buttons`

--- a/specs/issue-345-residual/requirements.md
+++ b/specs/issue-345-residual/requirements.md
@@ -1,0 +1,136 @@
+---
+spec: issue-345-residual
+phase: requirements
+created: 2026-04-28
+mode: quick
+---
+
+# Requirements: issue-345-residual
+
+## Goal
+
+Implement Section A items A1+A2 (meta description rewrites for #143 + #151 posts) and Section B item B1 (document spec artifact commit policy in CLAUDE.md). A3+A4 redirected to `cleanup/issue-209-best-for-buttons` per research finding — `bestForFilters` array does not exist on main, so editing it here would entangle branch state.
+
+## User Stories
+
+### US-1: Richer SERP snippets for #143 + #151 posts
+**As a** Google search-result viewer
+**I want** richer, click-motivating meta descriptions on the clinical-trials and NAC-vs-DHM posts
+**So that** the snippet entices clicks instead of describing study mechanics flatly
+
+**Acceptance Criteria:**
+- [ ] AC-1, AC-2, AC-3, AC-4, AC-5, AC-6 below
+
+### US-2: Documented spec-artifact commit policy
+**As a** future contributor opening this repo months from now
+**I want** a single canonical place stating which ralph-spec files get committed
+**So that** spec hygiene is consistent across branches and I don't have to reverse-engineer the convention
+
+**Acceptance Criteria:**
+- [ ] AC-7, AC-8, AC-9 below
+
+## Acceptance Criteria
+
+| ID | Criterion | Verification |
+|----|-----------|--------------|
+| **AC-1** | `src/newblog/data/posts/dhm-randomized-controlled-trials.json` `metaDescription` field equals verbatim text from issue #143: `"Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works."` (149 chars) | `jq -r '.metaDescription' src/newblog/data/posts/dhm-randomized-controlled-trials.json` matches exactly |
+| **AC-2** | That post's `title` field UNTOUCHED on this branch (title edit is on #143 branch; merging both layers cleanly because they're different fields) | `git diff main -- src/newblog/data/posts/dhm-randomized-controlled-trials.json` shows ONLY `metaDescription` change |
+| **AC-3** | `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` `metaDescription` field equals verbatim text from issue #151: `"NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice)."` (143 chars) | `jq -r '.metaDescription' …` matches exactly |
+| **AC-4** | That post's `title` field UNTOUCHED on this branch | `git diff main -- src/newblog/data/posts/nac-vs-dhm-…json` shows ONLY `metaDescription` change |
+| **AC-5** | After build, both meta descriptions appear in their respective `dist/never-hungover/<slug>/index.html` files | `grep -oE 'name="description" content="[^"]*"' dist/never-hungover/dhm-randomized-controlled-trials/index.html` and `…/nac-vs-dhm-…/index.html` show new text |
+| **AC-6** | `npm run build` exits 0; no JSON parse errors | `npm run build; echo $?` returns 0 |
+| **AC-7** | Spec policy documented via CLAUDE.md addition (option a — recommended for global discoverability) | New section header present in `CLAUDE.md` referring to spec hygiene |
+| **AC-8** | Policy text states: "For each spec under `specs/issue-*/`, commit all 4 markdown files (`research.md`, `requirements.md`, `design.md`, `tasks.md`). Do NOT commit `.progress.md` or `.ralph-state.json` — both are gitignored as working state." | `grep -A6 "Spec hygiene" CLAUDE.md` shows the policy text |
+| **AC-9** | A3 + A4 redirect to #209 documented in this spec's `tasks.md` so a future reader knows where they went | `grep -A4 "A3.*#209\|redirect.*209" specs/issue-345-residual/tasks.md` finds explicit note |
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|-------------|----------|---------------------|
+| FR-1 | Replace `metaDescription` in `dhm-randomized-controlled-trials.json` with verbatim issue #143 text | High | AC-1, AC-2 |
+| FR-2 | Replace `metaDescription` in `nac-vs-dhm-…2025.json` with verbatim issue #151 text | High | AC-3, AC-4 |
+| FR-3 | Add ~5-line "Spec hygiene" section to project `CLAUDE.md` stating commit policy | Medium | AC-7, AC-8 |
+| FR-4 | Document A3+A4 redirect to `cleanup/issue-209-best-for-buttons` in this spec's `tasks.md` | High | AC-9 |
+| FR-5 | Build remains green after all edits | High | AC-6 |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Metric | Target |
+|----|-------------|--------|--------|
+| NFR-1 | No fabricated meta-description text | Char-for-char match against issue body | 100% |
+| NFR-2 | No collateral edits to post JSONs (only `metaDescription`) | `git diff` on each file | Single field change |
+| NFR-3 | Build remains green | `npm run build` exit code | 0 |
+| NFR-4 | No new dependencies | `package.json` diff | No additions |
+| NFR-5 | CLAUDE.md edit uses unique section header to avoid future conflicts | Header text | "Spec hygiene" or similar non-collision-prone phrase |
+
+## Glossary
+
+- **`metaDescription`**: camelCase field in post JSONs at `src/newblog/data/posts/*.json` — the SEO description rendered into prerendered HTML's `<meta name="description">`.
+- **`bestForFilters`**: array in `src/pages/Reviews.jsx` defining filter-button predicates. Lives on `cleanup/issue-209-best-for-buttons`, NOT on main.
+- **Spec artifact**: one of `research.md`, `requirements.md`, `design.md`, `tasks.md` under `specs/issue-*/`. Per-policy: all 4 are committed.
+- **Working-state files**: `.progress.md`, `.ralph-state.json`, `.current-spec`, `.current-epic`, `.index/` — all gitignored.
+
+## Scope
+
+### In Scope
+- `src/newblog/data/posts/dhm-randomized-controlled-trials.json` — `metaDescription` field only
+- `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` — `metaDescription` field only
+- `CLAUDE.md` — add "Spec hygiene" section (~5 lines)
+- `specs/issue-345-residual/tasks.md` — document A3+A4 redirect
+
+### Out of Scope (Deferred to #209 branch)
+- **A3** match-count badges on `bestForFilters` buttons — implement on `cleanup/issue-209-best-for-buttons` directly
+- **A4** "Best Overall" regex expansion `\b(best|trusted)\b` → `\b(best|trust)\w*` — same redirect
+
+### Out of Scope (Per issue body)
+- Section C (merge sequencing — guidance, not code)
+- Section D (6 gated/deferred items: #157, #200, #205+#214, #51, #249, #28+#85)
+- Section E (recommendations, not code)
+- B2 cosmetic checkboxes on #251 (sealed branch)
+- Title field edits on the 2 target posts (those are on #143/#151 branches)
+- `.gitignore` changes (current state already correct per research)
+- Cosmetic spec-dir cleanup on past sealed branches
+
+## Edge Cases
+
+| Edge Case | Handling |
+|-----------|----------|
+| Field name might be `seo.description` instead of `metaDescription` | Research confirmed `metaDescription` (camelCase) on both files. No nested `seo` object. |
+| Recommended meta exceeds 160 chars | Verified: #143 = 149 chars, #151 = 143 chars. Both under 160 with safety margin. No trimming needed. |
+| CLAUDE.md merge conflict with parallel branches | Low risk — no other April 2026 branches edit CLAUDE.md. Use unique "Spec hygiene" section header to minimize collision surface. |
+| #143/#151 branches haven't merged when this lands | Clean — different JSON keys (title vs metaDescription) layer cleanly via 3-way merge regardless of order. |
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Future reader asks "why didn't A3/A4 ship on #345?" | Medium | Explicit, prominent note in `tasks.md` and PR body explaining the #209-branch redirect (AC-9 enforces this) |
+| Conflict with #143/#151 branches | Low | Title and metaDescription are different keys — clean 3-way merge guaranteed. AC-2 and AC-4 enforce title untouched. |
+| CLAUDE.md merge conflict | Low | No other live branches editing CLAUDE.md per April 2026 audit. |
+| Verbatim text typo (drifts from issue #143/#151 body) | Medium | Copy-paste from issue body; verify with `jq -r '.metaDescription' \| wc -c` matches expected char count (149 / 143) |
+| Build breaks from malformed JSON edit | Medium | `npm run validate-posts` runs in build chain; AC-6 catches this. |
+
+## Unresolved Questions
+
+None. Research phase resolved all ambiguities:
+- Field name confirmed (`metaDescription` camelCase, no nested `seo`)
+- Verbatim text and char counts confirmed (149 / 143)
+- A3/A4 redirect path confirmed (`cleanup/issue-209-best-for-buttons` is the correct branch)
+- CLAUDE.md location confirmed as the right venue for B1 policy doc
+
+## Success Criteria
+
+- 2 post JSONs have new `metaDescription` matching issues #143 + #151 verbatim
+- 1 CLAUDE.md addition documents spec-artifact commit policy in ~5 lines
+- 1 `tasks.md` note redirects A3+A4 to #209 branch
+- `npm run build` exits 0
+- New meta descriptions appear in prerendered HTML for both posts
+- No `title` field changes, no `.gitignore` changes, no other collateral edits
+
+## Next Steps
+
+1. Generate `design.md` — straightforward 4-task plan: 2 JSON edits, 1 CLAUDE.md addition, 1 tasks.md redirect note
+2. Generate `tasks.md` from design (must include AC-9 redirect documentation prominently)
+3. Execute tasks (data + doc edits only — no code logic changes)
+4. Verify build green; verify prerendered HTML contains new meta descriptions
+5. Open PR; reference issues #143, #151, #251, and #345; explicitly call out A3+A4 redirect to #209 in PR body

--- a/specs/issue-345-residual/research.md
+++ b/specs/issue-345-residual/research.md
@@ -1,0 +1,183 @@
+---
+spec: issue-345-residual
+phase: research
+created: 2026-04-28
+mode: quick
+---
+
+# Research: issue-345-residual
+
+## Executive Summary
+
+Issue #345 is an umbrella cleanup ticket. This run scopes down to **Section A (immediately-actionable)** + **Section B (policy clarification)** only — the issue body itself defers Section C (merge guidance, not code), Section D (gated on external data: PostHog, GSC, etc.), and Section E (recommendations, not code). In-scope: 2 meta-description rewrites (#143, #151), 1 regex expansion + 1 match-count badge feature on the #209 branch's Reviews.jsx, and a documented spec-artifact policy.
+
+## Critical Branch Topology
+
+A3 + A4 (`Reviews.jsx` work) cannot land on this branch alone. The `bestFor` button row + `/\b(best|trusted)\b/i` regex live on `cleanup/issue-209-best-for-buttons`, NOT on main. Per `.progress.md` strategic note: this branch must merge AFTER #209. Two viable execution paths:
+
+| Path | Description | Recommendation |
+|---|---|---|
+| **A** | Make the changes on this branch atop main; rely on merge-order to layer correctly | Risky — main lacks bestForFilters; edits would be against code that doesn't exist locally |
+| **B** | Rebase this branch onto `cleanup/issue-209-best-for-buttons` for the A3/A4 portion, OR cherry-pick the bestForFilters block into this branch first | **Recommended** — gives concrete code to edit and verify |
+
+A1 + A2 (post JSONs) and B1 (policy doc) are independent of this issue.
+
+## Per-Item Current State
+
+### A1 — #143 meta description (`src/newblog/data/posts/dhm-randomized-controlled-trials.json`)
+
+| Field | Value | Char count |
+|---|---|---|
+| Current `metaDescription` | `Peer-reviewed DHM clinical trials show 70% hangover reduction. UCLA and USC research explains exactly how DHM prevents hangovers.` | **129** |
+| Recommended (verbatim from issue #143) | `Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works.` | **149** |
+| Under 160? | Yes (both) | — |
+
+Field name in JSON: `metaDescription` (camelCase). Title field will be left untouched (already trimmed on `cleanup/issue-143-clinical-trials-title` to "DHM Clinical Trials 2026: 70% Hangover Reduction Proven").
+
+### A2 — #151 meta description (`src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`)
+
+| Field | Value | Char count |
+|---|---|---|
+| Current `metaDescription` | `NAC vs DHM for liver protection: NAC excels for daily support ($6-15/mo), DHM works best before drinking. Compare dosing, cost, and usage.` | **138** |
+| Recommended (verbatim from issue #151) | `NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice).` | **143** |
+| Under 160? | Yes (both) | — |
+
+Field name in JSON: `metaDescription` (camelCase). Title untouched (already updated on `cleanup/issue-151-nac-dhm-title`).
+
+### A3 — #209 match-count badge (`src/pages/Reviews.jsx` on `cleanup/issue-209-best-for-buttons`)
+
+The `bestForFilters` array lives at lines 408–414 (on the #209 branch):
+
+```js
+const bestForFilters = [
+  { id: 'all',     label: 'All Products',     match: () => true },
+  { id: 'overall', label: 'Best Overall',     match: (p) => /\b(best|trusted)\b/i.test(p.bestFor) },
+  { id: 'value',   label: 'Best Value',       match: (p) => /value/i.test(p.bestFor) },
+  { id: 'heavy',   label: 'Heavy Drinkers',   match: (p) => /(party|weekend|high-performer)/i.test(p.bestFor) },
+  { id: 'health',  label: 'Health-Conscious', match: (p) => /(health|liver)/i.test(p.bestFor) }
+]
+```
+
+The render loop is at line 619: `{bestForFilters.map(f => { ... })}`.
+
+**Recommended approach** (no useMemo overhead; topProducts is static): compute counts inline once before render:
+
+```js
+const filterCounts = bestForFilters.reduce((acc, f) => {
+  acc[f.id] = topProducts.filter(f.match).length
+  return acc
+}, {})
+```
+
+Then render `{f.label} ({filterCounts[f.id]})` inside the button. This computes 5 filters × 10 products = 50 predicate calls per render, trivial.
+
+### A4 — #209 regex expansion ("Best Overall" filter)
+
+**Exhaustive match table** (current vs proposed, against all 10 product `bestFor` strings):
+
+| ID | bestFor | Current `\b(best\|trusted)\b` | Expanded `\b(best\|trust)\w*` |
+|---|---|---|---|
+| 1 | Weekend warriors who want **the best** | match | match |
+| 2 | Value hunters who want pure DHM | — | — |
+| 3 | Health-conscious drinkers who protect their liver | — | — |
+| 4 | Bulk buyers who want maximum value | — | — |
+| 5 | Social drinkers who want **a trusted** brand | match | match |
+| 6 | Party people who need serious protection | — | — |
+| 7 | Travelers needing portable protection | — | — |
+| 8 | High-performers who want max potency | — | — |
+| 9 | Trendsetters who appreciate celebrity picks | — | — |
+| 10 | Research-driven buyers who **trust** reviews | — | **NEW match** |
+
+**Result**: expansion adds DHM Depot (id 10, "trust reviews") to "Best Overall" without over-matching anything else. No false positives across the 10 strings. Safe change.
+
+Note: issue #345's wider audit also flagged products 7 (Good Morning, "portable protection") and 9 (Fuller Health, "celebrity picks") as filter dead-zones. The recommended A4 fix addresses **only product 10**. Products 7 and 9 are explicitly accepted as "All Products only" per the simplified scope (no new filter category added).
+
+### B1 — Spec artifact policy (#251)
+
+**Current state of `.gitignore`** (lines 132–138, "Spec internal state (per ralph-specum)"):
+
+```
+specs/.current-spec
+specs/.current-epic
+specs/.index/
+**/.progress.md
+**/.ralph-state.json
+```
+
+**What this means**:
+- `tasks.md`, `research.md`, `requirements.md`, `design.md` — **NOT gitignored**, can be committed
+- `.progress.md`, `.ralph-state.json`, `.current-spec`, `.current-epic`, `.index/` — gitignored
+
+**Observed inconsistency**:
+- Older specs (e.g., `issue-268-implementation`, `issue-285-newsletter` through `issue-304-what-to-eat`): commit all 4 artifacts (`research.md`, `requirements.md`, `design.md`, `tasks.md`). Some also commit `plan.md`.
+- Recent April 2026 cleanup branches (`issue-117`, `issue-143`, `issue-151`, `issue-158`, `issue-208`, `issue-209`, `issue-251`, …): the issue #345 audit found these have **only `tasks.md` committed on their branches**, with `research.md`/`requirements.md`/`design.md` left untracked on disk.
+
+**Canonical policy recommendation**: keep current `.gitignore` (no changes). Document the policy in a single sentence: **"All four ralph-specum artifacts (`research.md`, `requirements.md`, `design.md`, `tasks.md`) should be committed per spec — they form the durable spec record. Only `.progress.md` and `.ralph-state.json` are working-state and remain gitignored."**
+
+**Why not extend gitignore to also exclude `research/requirements/design.md`?** Two reasons:
+1. The 30+ older specs already establish the precedent of committing all 4. Reversing that would orphan that history.
+2. These files are durable design records — useful to anyone reading the repo months later. They're not transient like `.progress.md`.
+
+The April 2026 cleanup branches' inconsistency is a **per-branch hygiene gap**, not a policy gap. Per `.progress.md`, those branches are already sealed and out of scope for this run; the policy applies forward.
+
+## Out-of-Scope Confirmation
+
+This run does NOT implement:
+- **Section C** (merge sequencing guidance for the 13 awaiting branches) — not code, just documentation
+- **Section D** (6 deferred/gated items: #157, #200, #205+#214, #51, #249, #28+#85) — gated on external data (PostHog, GSC) or precursor work
+- **Section E** (recommendations for next push) — not code
+- **B2** (cosmetic checkbox toggling on #251's tasks.md) — that branch is sealed
+- Cosmetic spec-dir cleanup on past sealed branches
+
+Per the issue body: "These were intentionally NOT implemented because they're gated on external data or require precursor work."
+
+## Risk Register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| A1/A2 conflict with existing #143/#151 branches | Low | Touch ONLY `metaDescription` field; leave `title` untouched. #143/#151 branches changed `title`; this branch changes `metaDescription`. Different fields = clean 3-way merge. |
+| A3/A4 conflict because `bestForFilters` doesn't exist on main | **High** | Either (a) merge #209 first then rebase this branch, or (b) cherry-pick the bestForFilters block from #209 into this branch's working tree. **Recommend path (b)** — keeps execution self-contained. Alternative: scope A3/A4 out of this branch and add to #209 directly. |
+| A4 regex over-matches | Very Low | Verified exhaustively against all 10 `bestFor` strings (table above). Adds 1 new match (id 10), removes none. No false positives. |
+| B1 policy doc has no enforceable artifact | Low | Doc-only change. Policy is captured in this research.md and will be the canonical reference. No code/config change. |
+| Both AC items in #143/#151 (title + meta) appear on different branches | Low | Issue #345 explicitly calls this out as the "deferred" portion. The path forward is clean: title on #143/#151 branches, meta on this branch. Merge order: #143 → #151 → this. |
+
+## Verification Approach
+
+| Item | Verification |
+|---|---|
+| A1 | `jq -r '.metaDescription \| length' src/newblog/data/posts/dhm-randomized-controlled-trials.json` returns ≤160; `jq -r '.title' …` unchanged from #143 branch's value |
+| A2 | Same as A1 against `nac-vs-dhm-...json` |
+| A3 | `npm run build` succeeds; `grep -oE 'All Products \([0-9]+\)\|Best Overall \([0-9]+\)\|Best Value \([0-9]+\)\|Heavy Drinkers \([0-9]+\)\|Health-Conscious \([0-9]+\)' dist/index.html` finds all 5 patterns; spot-check counts: All=10, Overall=3 (after A4), Value=2, Heavy=3, Health=2 |
+| A4 | Manual verification: render reviews page, click "Best Overall" filter; DHM Depot (id 10) MUST appear. Or grep test: `node -e "const re=/\b(best\|trust)\w*/i; console.log(re.test('Research-driven buyers who trust reviews'))"` returns `true` |
+| B1 | `grep -A2 'Spec internal state' .gitignore` confirms current entries unchanged. Policy text added to research.md is the canonical reference. |
+
+## Quality Commands
+
+| Type | Command | Source |
+|---|---|---|
+| Lint | `npm run lint` | package.json scripts.lint |
+| Build | `npm run build` | package.json scripts.build (also runs `validate-posts`, `verify-z-classes`, prerender) |
+| Validate posts | `npm run validate-posts` | package.json scripts.validate-posts (runs in build chain — catches malformed JSON) |
+
+No separate typecheck/test scripts in this project (Vite + plain JSX). The `build` chain is the local CI.
+
+## Sources
+
+- `/Users/patrickkavanagh/dhm-guide-website/specs/issue-345-residual/.progress.md` — in-scope/out-of-scope split
+- GitHub issue #345 (`gh issue view 345 --repo kavanaghpatrick/dhm-guide-website`) — full umbrella scope
+- GitHub issue #143 — verbatim recommended `metaDescription` text
+- GitHub issue #151 — verbatim recommended `metaDescription` text
+- `/Users/patrickkavanagh/dhm-guide-website/src/newblog/data/posts/dhm-randomized-controlled-trials.json` — current `metaDescription` value
+- `/Users/patrickkavanagh/dhm-guide-website/src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` — current `metaDescription` value
+- `/Users/patrickkavanagh/dhm-guide-website/src/pages/Reviews.jsx` (main) — confirms category-based filter still on main
+- `cleanup/issue-209-best-for-buttons:src/pages/Reviews.jsx` lines 408–414 — `bestForFilters` array with current regex
+- `/Users/patrickkavanagh/dhm-guide-website/.gitignore` lines 132–138 — current spec artifact policy
+- `git ls-files specs/` — older specs commit all 4 artifacts (#268, #285–#304); cleanup branches don't
+
+## Recommendations for Requirements Phase
+
+1. Define A1 and A2 as data-only edits to `metaDescription` field; explicitly forbid changes to `title`, `excerpt`, `quickAnswer`, or any other field
+2. For A3/A4, decide path: cherry-pick #209's bestForFilters into this branch, OR add A3/A4 to #209 branch and remove from this scope
+3. B1 ships as documentation in `research.md` only — no `.gitignore` change, no spec-dir mass-cleanup
+4. Verification gate: `npm run build` must pass before commit (catches malformed JSON, missing tokens, etc.)
+5. Treat each item (A1, A2, A3, A4, B1) as an independent task — no cross-coupling

--- a/specs/issue-345-residual/tasks.md
+++ b/specs/issue-345-residual/tasks.md
@@ -1,0 +1,182 @@
+---
+spec: issue-345-residual
+phase: tasks
+created: 2026-04-28
+mode: quick
+---
+
+# Tasks: issue-345-residual
+
+## Phase 1: Make It Work
+
+Focus: Two single-field JSON edits, one CLAUDE.md insertion, one spec-redirect note. Data + docs only — no code logic changes.
+
+### Group 1: Meta description rewrites
+
+- [x] 1.1 Edit `dhm-randomized-controlled-trials.json` metaDescription field
+  - **Do**:
+    1. Open `src/newblog/data/posts/dhm-randomized-controlled-trials.json`
+    2. Replace ONLY the `metaDescription` field value with verbatim text from design.md D2: `"Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works."`
+    3. Confirm `title`, `excerpt`, `quickAnswer`, and all other fields are untouched
+    4. Confirm JSON is still valid: `node -e "JSON.parse(require('fs').readFileSync('src/newblog/data/posts/dhm-randomized-controlled-trials.json','utf8'))"`
+  - **Files**: `src/newblog/data/posts/dhm-randomized-controlled-trials.json`
+  - **Done when**: `metaDescription` matches verbatim text (149 chars); JSON valid; no other fields changed
+  - **Verify**: `node -e "const p=JSON.parse(require('fs').readFileSync('src/newblog/data/posts/dhm-randomized-controlled-trials.json','utf8')); if(p.metaDescription.length===149 && p.metaDescription.startsWith('Breakthrough 2024')) console.log('1.1_PASS'); else process.exit(1)"`
+  - **Commit**: `fix(seo): rewrite #143 meta description per issue acceptance criteria`
+  - **Stage**: `src/newblog/data/posts/dhm-randomized-controlled-trials.json` only
+  - _Requirements: AC-1_
+
+- [x] 1.2 Edit `nac-vs-dhm-...2025.json` metaDescription field
+  - **Do**:
+    1. Open `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`
+    2. Replace ONLY the `metaDescription` field value with verbatim text from design.md D2: `"NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice)."`
+    3. Confirm `title`, `excerpt`, `quickAnswer`, and all other fields are untouched
+    4. Confirm JSON is still valid: `node -e "JSON.parse(require('fs').readFileSync('src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json','utf8'))"`
+  - **Files**: `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json`
+  - **Done when**: `metaDescription` matches verbatim text (143 chars); JSON valid; no other fields changed
+  - **Verify**: `node -e "const p=JSON.parse(require('fs').readFileSync('src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json','utf8')); if(p.metaDescription.length===143 && p.metaDescription.startsWith('NAC vs DHM')) console.log('1.2_PASS'); else process.exit(1)"`
+  - **Commit**: `fix(seo): rewrite #151 meta description per issue acceptance criteria`
+  - **Stage**: `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` only
+  - _Requirements: AC-3_
+
+- [x] 1.3 [VERIFY] Verify both meta descriptions and confirm titles untouched
+  - **Do**:
+    1. Print length and value for both metaDescriptions
+    2. Diff against main to confirm `title` is NOT in either changeset
+    3. Run JSON validity check on both files
+  - **Verify**:
+    ```bash
+    set -e
+    for slug in dhm-randomized-controlled-trials nac-vs-dhm-which-antioxidant-better-liver-protection-2025; do
+      node -e "const p=JSON.parse(require('fs').readFileSync('src/newblog/data/posts/$slug.json','utf8')); console.log('$slug:', p.metaDescription.length, 'chars'); console.log('  text:', p.metaDescription);"
+    done
+    git diff main..HEAD -- src/newblog/data/posts/dhm-randomized-controlled-trials.json | grep '"title":' && { echo "FAIL: title was changed in dhm-randomized-controlled-trials.json"; exit 1; } || echo "title untouched in dhm-randomized-controlled-trials.json"
+    git diff main..HEAD -- src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json | grep '"title":' && { echo "FAIL: title was changed in nac-vs-dhm-...json"; exit 1; } || echo "title untouched in nac-vs-dhm-...json"
+    echo "1.3_PASS"
+    ```
+  - **Done when**: Both metas print at 149/143 chars with correct text; both `title` greps return non-zero (no title diff); script ends in `1.3_PASS`
+  - **Commit**: None (verification only)
+  - _Requirements: AC-2, AC-4, AC-5_
+
+### Group 2: Document spec artifact commit policy
+
+- [x] 2.1 Insert "Spec Artifact Commit Policy" section into CLAUDE.md
+  - **Do**:
+    1. Open `CLAUDE.md`
+    2. Locate the `---` divider that follows the `## 🔄 Continuous Improvement` section (immediately before `## ⚠️ Red Flags (STOP and Simplify)`)
+    3. Insert a new `## Spec Artifact Commit Policy` section between that `---` and the `## ⚠️ Red Flags` heading, using the exact 14-line content block from design.md File 3:
+       ```markdown
+       ## Spec Artifact Commit Policy
+
+       For each `specs/issue-*/` directory, commit:
+       - `research.md`
+       - `requirements.md`
+       - `design.md`
+       - `tasks.md`
+
+       Do NOT commit:
+       - `.progress.md` (gitignored — working notes that change frequently)
+       - `.ralph-state.json` (gitignored — runtime state)
+
+       This ensures spec history is reviewable in PR while runtime artifacts stay out of the diff.
+
+       ---
+       ```
+    4. Confirm the `## ⚠️ Red Flags (STOP and Simplify)` heading still appears immediately after the new section's `---` divider
+  - **Files**: `CLAUDE.md`
+  - **Done when**: New section is present at correct location; existing sections (Continuous Improvement, Red Flags) untouched in content
+  - **Verify**: `grep -A 12 "^## Spec Artifact Commit Policy" CLAUDE.md | grep -q "tasks.md" && grep -A 14 "^## Spec Artifact Commit Policy" CLAUDE.md | grep -q "ralph-state.json" && echo 2.1_PASS`
+  - **Commit**: `docs(claude): document spec artifact commit policy (#345 B1)`
+  - **Stage**: `CLAUDE.md` only
+  - _Requirements: AC-7, AC-8_
+
+- [x] 2.2 [VERIFY] Confirm CLAUDE.md policy section is canonical
+  - **Do**:
+    1. Print the full new section from CLAUDE.md
+    2. Confirm all 4 artifact filenames and both gitignored filenames appear
+  - **Verify**:
+    ```bash
+    set -e
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q "research.md" || { echo "FAIL: research.md missing"; exit 1; }
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q "requirements.md" || { echo "FAIL: requirements.md missing"; exit 1; }
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q "design.md" || { echo "FAIL: design.md missing"; exit 1; }
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q "tasks.md" || { echo "FAIL: tasks.md missing"; exit 1; }
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q ".progress.md" || { echo "FAIL: .progress.md missing"; exit 1; }
+    grep -A 15 "## Spec Artifact Commit Policy" CLAUDE.md | grep -q ".ralph-state.json" || { echo "FAIL: .ralph-state.json missing"; exit 1; }
+    echo "2.2_PASS"
+    ```
+  - **Done when**: All 6 filenames present in section; ends in `2.2_PASS`
+  - **Commit**: None (verification only)
+  - _Requirements: AC-7, AC-8_
+
+### Group 3: Build verification
+
+- [x] 3.1 [VERIFY] Run `npm run build` and confirm prerendered meta tags
+  - **Do**:
+    1. Run `npm run build`; expect exit code 0
+    2. Grep both prerendered HTML files for the new meta description text
+  - **Verify**:
+    ```bash
+    set -e
+    npm run build
+    DHM_META=$(grep -oE 'name="description" content="[^"]*"' dist/never-hungover/dhm-randomized-controlled-trials/index.html | head -1)
+    NAC_META=$(grep -oE 'name="description" content="[^"]*"' dist/never-hungover/nac-vs-dhm-which-antioxidant-better-liver-protection-2025/index.html | head -1)
+    echo "DHM: $DHM_META"
+    echo "NAC: $NAC_META"
+    echo "$DHM_META" | grep -q "Breakthrough 2024" || { echo "FAIL: DHM prerendered meta wrong"; exit 1; }
+    echo "$NAC_META" | grep -q "Which protects your liver better" || { echo "FAIL: NAC prerendered meta wrong"; exit 1; }
+    echo "3.1_PASS"
+    ```
+  - **Done when**: Build exits 0; both prerendered HTML files contain new meta text
+  - **Commit**: None (verification only)
+  - _Requirements: AC-5, AC-6_
+
+### Group 4: Spec scaffold + redirect note
+
+- [x] 4.1 Confirm A3+A4 redirect note already present in this tasks.md (this file)
+  - **Do**:
+    1. Confirm the `## Notes — A3 + A4 Redirect` section at the end of this file (`specs/issue-345-residual/tasks.md`) is present and accurate
+    2. Stage all four spec artifacts together (research.md, requirements.md, design.md, tasks.md) per the new policy in CLAUDE.md
+  - **Files**: `specs/issue-345-residual/research.md`, `specs/issue-345-residual/requirements.md`, `specs/issue-345-residual/design.md`, `specs/issue-345-residual/tasks.md`
+  - **Done when**: All 4 spec artifacts staged; redirect note prominent at end of tasks.md
+  - **Verify**: `grep -q "A3 + A4 Redirect" specs/issue-345-residual/tasks.md && echo 4.1_PASS`
+  - **Commit**: `chore(spec): scaffold ralph spec artifacts for issue #345`
+  - **Stage**: `specs/issue-345-residual/research.md`, `specs/issue-345-residual/requirements.md`, `specs/issue-345-residual/design.md`, `specs/issue-345-residual/tasks.md` (explicit paths only — practicing the new policy)
+  - _Requirements: AC-9_
+
+- [x] 4.2 [VERIFY] Confirm A3+A4 redirect note is present and complete
+  - **Do**: Grep tasks.md for the redirect note heading and key body content
+  - **Verify**:
+    ```bash
+    set -e
+    grep -A1 "A3 + A4 Redirect" specs/issue-345-residual/tasks.md
+    grep -q "A3 + A4 Redirect" specs/issue-345-residual/tasks.md || { echo "FAIL: redirect heading missing"; exit 1; }
+    grep -q "cleanup/issue-209-best-for-buttons" specs/issue-345-residual/tasks.md || { echo "FAIL: redirect target branch not named"; exit 1; }
+    grep -q "bestForFilters" specs/issue-345-residual/tasks.md || { echo "FAIL: redirect rationale missing"; exit 1; }
+    echo "4.2_PASS"
+    ```
+  - **Done when**: All 3 grep checks pass; ends in `4.2_PASS`
+  - **Commit**: None (verification only)
+  - _Requirements: AC-9_
+
+## Notes — A3 + A4 Redirect
+
+Per research.md finding: `bestForFilters` array (target of A3 match-count badges + A4 regex expansion) was added on `cleanup/issue-209-best-for-buttons` and does NOT exist on main. This branch off main cannot edit code that doesn't exist here.
+
+**Action**: amend the #209 branch with two follow-up commits (one for A3, one for A4) BEFORE merging it. OR ship #209 as-is and file a focused #345-followup issue for A3 + A4 specifically.
+
+Decision deferred to user at merge time.
+
+## Commit Order Summary
+
+| # | After task | Commit message | Stages |
+|---|---|---|---|
+| 1 | 1.1 | `fix(seo): rewrite #143 meta description per issue acceptance criteria` | `src/newblog/data/posts/dhm-randomized-controlled-trials.json` |
+| 2 | 1.2 | `fix(seo): rewrite #151 meta description per issue acceptance criteria` | `src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json` |
+| 3 | 2.1 | `docs(claude): document spec artifact commit policy (#345 B1)` | `CLAUDE.md` |
+| 4 | 4.1 | `chore(spec): scaffold ralph spec artifacts for issue #345` | `specs/issue-345-residual/{research,requirements,design,tasks}.md` (4 files explicit) |
+
+Total expected commits: **4**.
+
+User handles `git push` and PR creation; PR body must explicitly call out A3+A4 redirect to `cleanup/issue-209-best-for-buttons`.

--- a/src/newblog/data/posts/dhm-randomized-controlled-trials.json
+++ b/src/newblog/data/posts/dhm-randomized-controlled-trials.json
@@ -4,7 +4,7 @@
   "slug": "dhm-randomized-controlled-trials",
   "excerpt": "Peer-reviewed clinical trial proves DHM reduces hangover severity by 70% (p<0.001). See the UCLA, USC, and Foods journal research that validates DHM's effectiveness.",
   "quickAnswer": "Peer-reviewed clinical trial proves DHM reduces hangover severity by 70% (p<0.001). See the UCLA, USC, and Foods journal research that validates DHM's effectiveness.",
-  "metaDescription": "Peer-reviewed DHM clinical trials show 70% hangover reduction. UCLA and USC research explains exactly how DHM prevents hangovers.",
+  "metaDescription": "Breakthrough 2024 study proves DHM cuts hangover severity by 70%. See the peer-reviewed results from Foods journal that explain exactly how it works.",
   "date": "2025-06-28",
   "dateModified": "2026-04-26",
   "author": "DHM Guide Team",

--- a/src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json
+++ b/src/newblog/data/posts/nac-vs-dhm-which-antioxidant-better-liver-protection-2025.json
@@ -3,7 +3,7 @@
   "slug": "nac-vs-dhm-which-antioxidant-better-liver-protection-2025",
   "excerpt": "Scientific comparison of NAC and DHM for liver protection. Learn the mechanisms, benefits, and optimal use cases for each antioxidant supplement.",
   "quickAnswer": "Scientific comparison of NAC and DHM for liver protection. Learn the mechanisms, benefits, and optimal use cases for each antioxidant supplement.",
-  "metaDescription": "NAC vs DHM for liver protection: NAC excels for daily support ($6-15/mo), DHM works best before drinking. Compare dosing, cost, and usage.",
+  "metaDescription": "NAC vs DHM: Which protects your liver better? Complete comparison reveals when to use each (and why combining them may be the smartest choice).",
   "date": "2025-07-09",
   "author": "DHM Guide Team",
   "tags": [


### PR DESCRIPTION
Refs #345 (partial — A1 + A2 + B1 only; A3 + A4 redirected to #209; D items deferred)

**A1 (#143 meta)**: \`metaDescription\` → 149 chars verbatim from #143 issue body. Layers on top of #143's title fix (different field, no conflict).

**A2 (#151 meta)**: \`metaDescription\` → 143 chars verbatim from #151 issue body. Same layering pattern.

**B1 (spec policy)**: new \`## Spec Artifact Commit Policy\` section in CLAUDE.md (~14 lines) documenting which spec artifacts get committed (research/requirements/design/tasks.md) vs gitignored (.progress.md, .ralph-state.json).

**A3 + A4 redirect**: target \`bestForFilters\` lives only on \`cleanup/issue-209-best-for-buttons\`, not main. Documented in spec's \`tasks.md\` lines 163-169 — should be amended onto #209 directly.

**D items deferred** intentionally (gated on data we don't have): #157, #200, #205+#214, #51, #249, #28+#85.

This PR keeps #345 OPEN — D items + A3 + A4 still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)