### PR TITLE
fix(metadata): remove orphans, generate reverse-orphans, audit script (#84)

### DIFF
--- a/scripts/audit-orphan-metadata.mjs
+++ b/scripts/audit-orphan-metadata.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Audit orphans in src/newblog/data/metadata/index.json relative to src/newblog/data/posts/*.json
+//
+// - orphans         = metadata entries pointing to a slug whose post file is missing
+// - reverse-orphans = post files whose slug has no metadata entry
+//
+// Usage: node scripts/audit-orphan-metadata.mjs
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const POSTS_DIR = join(ROOT, 'src/newblog/data/posts')
+const METADATA_PATH = join(ROOT, 'src/newblog/data/metadata/index.json')
+
+if (!existsSync(POSTS_DIR)) {
+  console.error(`Posts dir missing: ${POSTS_DIR}`)
+  process.exit(2)
+}
+if (!existsSync(METADATA_PATH)) {
+  console.error(`Metadata file missing: ${METADATA_PATH}`)
+  process.exit(2)
+}
+
+const postSlugs = new Set(
+  readdirSync(POSTS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, '')),
+)
+
+const metadata = JSON.parse(readFileSync(METADATA_PATH, 'utf8'))
+if (!Array.isArray(metadata)) {
+  console.error('Metadata index.json is not an array')
+  process.exit(2)
+}
+
+const metadataSlugs = new Set(metadata.map((e) => e.slug))
+
+const orphans = metadata
+  .filter((e) => !postSlugs.has(e.slug))
+  .map((e) => e.slug)
+
+const reverseOrphans = [...postSlugs].filter((s) => !metadataSlugs.has(s))
+
+const slugCounts = new Map()
+for (const e of metadata) slugCounts.set(e.slug, (slugCounts.get(e.slug) ?? 0) + 1)
+const duplicateSlugs = [...slugCounts.entries()]
+  .filter(([, n]) => n > 1)
+  .map(([s, n]) => ({ slug: s, count: n }))
+
+console.log(`Posts on disk:       ${postSlugs.size}`)
+console.log(`Metadata entries:    ${metadata.length}`)
+console.log(`Orphans (meta→file): ${orphans.length}`)
+console.log(`Reverse-orphans:     ${reverseOrphans.length}`)
+console.log(`Duplicate slugs:     ${duplicateSlugs.length}`)
+
+if (orphans.length) {
+  console.log('\nOrphans (metadata entries with no post file):')
+  for (const s of orphans) console.log(`  - ${s}`)
+}
+
+if (reverseOrphans.length) {
+  console.log('\nReverse-orphans (post files with no metadata entry):')
+  for (const s of reverseOrphans) console.log(`  - ${s}`)
+}
+
+if (duplicateSlugs.length) {
+  console.log('\nDuplicate slugs in metadata:')
+  for (const d of duplicateSlugs) console.log(`  ~ ${d.slug} (${d.count}x)`)
+}
+
+if (orphans.length || reverseOrphans.length || duplicateSlugs.length) process.exit(1)
+console.log('\nClean.')

--- a/scripts/fix-orphan-metadata.mjs
+++ b/scripts/fix-orphan-metadata.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// One-shot fixer for issue #84:
+//   - Removes orphan metadata entries (slug points to a missing post file)
+//   - Adds metadata entries for reverse-orphan posts (post file with no metadata entry)
+//
+// Stable ordering: existing entries keep their position; new entries are appended
+// in slug order at the end of the array. The companion audit script
+// (audit-orphan-metadata.mjs) should report 0/0 after this runs.
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const POSTS_DIR = join(ROOT, 'src/newblog/data/posts')
+const METADATA_PATH = join(ROOT, 'src/newblog/data/metadata/index.json')
+
+const postSlugs = new Set(
+  readdirSync(POSTS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, '')),
+)
+
+const metadata = JSON.parse(readFileSync(METADATA_PATH, 'utf8'))
+if (!Array.isArray(metadata)) throw new Error('metadata index.json is not an array')
+
+const removedSlugs = []
+const dedupedSlugs = []
+const seen = new Set()
+const kept = metadata.filter((e) => {
+  if (!postSlugs.has(e.slug)) {
+    removedSlugs.push(e.slug)
+    return false
+  }
+  if (seen.has(e.slug)) {
+    dedupedSlugs.push(e.slug)
+    return false
+  }
+  seen.add(e.slug)
+  return true
+})
+
+const metadataSlugs = new Set(kept.map((e) => e.slug))
+const reverseOrphans = [...postSlugs].filter((s) => !metadataSlugs.has(s)).sort()
+
+const added = []
+for (const slug of reverseOrphans) {
+  const postPath = join(POSTS_DIR, `${slug}.json`)
+  if (!existsSync(postPath)) continue
+  const post = JSON.parse(readFileSync(postPath, 'utf8'))
+
+  const entry = {
+    id: post.id ?? slug,
+    slug,
+    title: post.title ?? slug,
+    excerpt: post.excerpt ?? post.description ?? '',
+    date: post.date ?? post.publishedAt ?? '',
+    author: post.author ?? 'DHM Guide Team',
+    image: post.image ?? null,
+    tags: Array.isArray(post.tags) ? post.tags : [],
+    readTime: post.readTime ?? 10,
+  }
+  added.push(entry)
+}
+
+const next = [...kept, ...added]
+
+writeFileSync(METADATA_PATH, JSON.stringify(next, null, 2) + '\n')
+
+console.log(`Removed ${removedSlugs.length} orphan metadata entries:`)
+for (const s of removedSlugs) console.log(`  - ${s}`)
+console.log(`\nDeduplicated ${dedupedSlugs.length} duplicate metadata entries:`)
+for (const s of dedupedSlugs) console.log(`  ~ ${s}`)
+console.log(`\nAdded ${added.length} metadata entries for reverse-orphan posts:`)
+for (const e of added) console.log(`  + ${e.slug}`)
+console.log(`\nMetadata count: ${metadata.length} -> ${next.length}`)

--- a/specs/issue-84-orphan-metadata/tasks.md
+++ b/specs/issue-84-orphan-metadata/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — Issue #84: Clean Up Orphaned Metadata Entries
+
+Phase 2 data hygiene for `src/newblog/data/metadata/index.json`.
+
+## Audit scope (per ultrathink)
+
+The issue body names 4 known orphan slugs. The audit reveals the issue is bidirectional:
+
+- **Orphans** — metadata entries pointing to a slug whose post file is missing.
+  Forward direction: blog listing rendering an entry that 404s when clicked.
+- **Reverse-orphans** — post files whose slug has no metadata entry.
+  Reverse direction: post exists on disk but never appears in the listing.
+
+We fix BOTH directions in a single pass, plus dedupe one literal duplicate slug
+discovered during audit.
+
+## Tasks
+
+- [x] T1. Write `scripts/audit-orphan-metadata.mjs` that lists orphans, reverse-orphans, and duplicate slugs. Exit non-zero if any are found.
+- [x] T2. Run audit on `main`. Confirm: 5 orphans, 13 reverse-orphans, 1 duplicate slug.
+  - Orphans: 4 from issue body + `flyby-vs-fuller-health-complete-comparison-2025` (slug-rename casualty; the actual post lives at `flyby-vs-fuller-health-complete-comparison` without `-2025`).
+  - Reverse-orphans: 13 post files lacking metadata entries.
+  - Duplicate slug: `alcohol-work-performance-professional-impact-guide-2025` appears 2x with byte-identical entries.
+- [x] T3. Write `scripts/fix-orphan-metadata.mjs`:
+  - Filter out entries whose slug isn't on disk (orphan removal).
+  - Filter out duplicate slug occurrences (keep first).
+  - Append metadata entries for each reverse-orphan, derived from the post JSON's slug/title/excerpt/date/author/image/tags/readTime fields, schema-matched to existing entries.
+  - Stable order: existing entries keep their position; new entries appended in slug order.
+- [x] T4. Run fix script. Verify metadata count goes 190 → 197 (-5 orphans -1 dup +13 reverse-orphans).
+- [x] T5. Re-run audit script: must report 0/0/0 (orphans/reverse-orphans/duplicates).
+- [x] T6. `npm run build` — must succeed and prerender 197 posts.
+- [x] T7. Spot-check dist output: at least one new reverse-orphan slug present in `dist/never-hungover/`, none of the removed orphan slugs present.
+- [x] T8. Two commits with Co-Authored-By trailer:
+  - `fix(metadata): remove 5 orphan entries, dedupe 1, generate 13 missing reverse-orphans (#84)` — stage only `src/newblog/data/metadata/index.json` and the two scripts (`scripts/audit-orphan-metadata.mjs`, `scripts/fix-orphan-metadata.mjs`).
+  - `chore(spec): scaffold ralph spec artifacts for issue #84` — stage only this file.
+- [x] T9. Stay on branch `cleanup/issue-84-orphan-metadata`. No push, no PR.
+
+## Verification commands
+
+```bash
+node scripts/audit-orphan-metadata.mjs   # → 0/0/0, exit 0
+npm run build                             # → "Found 197 valid blog posts to prerender"
+```
+
+## Out of scope
+
+- The 23 comparison posts referenced in the issue body's "Phase 1" prerequisite — already restored prior to this branch.
+- Slug normalization or post-content edits.
+- The `index.backup.json`, `index.json.backup2`, `index.json.bak`, `index.json.tmp` sidecar files in the metadata directory (separate cleanup).
+- The `stats.json` file in the metadata directory (different concern).

--- a/src/newblog/data/metadata/index.json
+++ b/src/newblog/data/metadata/index.json
@@ -268,97 +268,6 @@
     "readTime": "33 minutes"
   },
   {
-    "id": "smart-sleep-tech-alcohol-circadian-optimization-guide-2025",
-    "slug": "smart-sleep-tech-alcohol-circadian-optimization-guide-2025",
-    "title": "Smart Sleep Tech Alcohol Circadian Optimization Guide 2025",
-    "excerpt": "This post is being updated. Please check back soon.",
-    "date": "2025-07-29",
-    "author": "DHM Guide Team",
-    "image": "/images/smart-sleep-tech-alcohol-circadian-optimization-guide-2025-hero.webp",
-    "tags": [
-      "health",
-      "alcohol",
-      "wellness"
-    ],
-    "readTime": 10
-  },
-  {
-    "id": "quantum-health-monitoring-alcohol-guide-2025",
-    "slug": "quantum-health-monitoring-alcohol-guide-2025",
-    "title": "Quantum Health Monitoring Alcohol Guide 2025",
-    "excerpt": "This post is being updated. Please check back soon.",
-    "date": "2025-07-29",
-    "author": "DHM Guide Team",
-    "image": "/images/quantum-health-monitoring-alcohol-guide-2025-hero.webp",
-    "tags": [
-      "health",
-      "alcohol",
-      "wellness"
-    ],
-    "readTime": 10
-  },
-  {
-    "id": 181,
-    "slug": "alcohol-hormones-complete-endocrine-impact-guide-2025",
-    "title": "Alcohol and Hormones: Complete Endocrine Impact Guide (2025)",
-    "excerpt": "",
-    "date": "2025-07-29",
-    "author": "DHM Guide Team",
-    "image": "/images/alcohol-hormones-complete-endocrine-impact-guide-2025-hero.webp",
-    "tags": [
-      "alcohol",
-      "hormones",
-      "endocrine system",
-      "testosterone",
-      "estrogen",
-      "thyroid",
-      "cortisol",
-      "DHM",
-      "liver health",
-      "hormonal balance"
-    ],
-    "readTime": "15 min read"
-  },
-  {
-    "id": "alcohol-work-performance-professional-impact-guide-2025",
-    "slug": "alcohol-work-performance-professional-impact-guide-2025",
-    "title": "Alcohol and Work Performance: Professional Impact Guide (2025)",
-    "excerpt": "In the dynamic landscape of modern careers, the pursuit of peak performance and sustained productivity is paramount. Professionals are constantly seeking edges, whether through optimized routines, enhanced cognitive function, or strategic networking. Yet, an often-overlooked factor subtly influencing these critical aspects is alcohol consumption. While the overt dangers of alcohol abuse are widely recognized, the nuanced impact of moderate or even seemingly casual drinking on daily work performance, long-term career trajectories, and the evolving professional drinking culture often remains unexamined. This comprehensive guide delves into the science-backed realities of how alcohol interacts with cognitive function, affects productivity, shapes workplace relationships, and ultimately influences career optimization in 2025. We will explore not just the pitfalls, but also practical strategies for navigating social drinking, enhancing well-being, and fostering a professional environment where clarity and peak performance are prioritized.",
-    "date": "2025-07-28",
-    "author": "DHM Guide Team",
-    "image": "/images/alcohol-work-performance-professional-impact-guide-2025-hero.webp",
-    "tags": [
-      "alcohol",
-      "work performance",
-      "productivity",
-      "career",
-      "professional drinking",
-      "cognitive function",
-      "DHM Guide"
-    ],
-    "readTime": 13
-  },
-  {
-    "id": "cold-therapy-alcohol-recovery-guide-2025",
-    "slug": "cold-therapy-alcohol-recovery-complete-guide-2025",
-    "title": "Cold Therapy and Alcohol Recovery: Complete Guide (2025)",
-    "excerpt": "Explore how cold therapy, including ice baths and cryotherapy, combined with DHM, can significantly aid in alcohol recovery and hangover relief. This comprehensive guide delves into the science, practical applications, and synergistic benefits of this powerful duo.",
-    "date": "2025-07-28",
-    "author": "DHM Guide Team",
-    "image": "/images/cold-therapy-alcohol-recovery-complete-guide-2025-hero.webp",
-    "tags": [
-      "cold therapy",
-      "alcohol recovery",
-      "hangover relief",
-      "ice bath",
-      "cryotherapy",
-      "DHM",
-      "health",
-      "wellness"
-    ],
-    "readTime": "15 min"
-  },
-  {
     "id": "alcohol-work-performance-professional-impact-guide-2025",
     "slug": "alcohol-work-performance-professional-impact-guide-2025",
     "title": "Alcohol and Work Performance: Professional Impact Guide (2025)",
@@ -1311,23 +1220,6 @@
       "comparison",
       "clinical trials",
       "dhm supplements"
-    ],
-    "image": "/images/flyby-recovery-review-2025-hero.webp",
-    "readTime": 8
-  },
-  {
-    "id": "flyby-vs-fuller-health-complete-comparison-2025",
-    "title": "Flyby vs Fuller Health: Complete 2025 Comparison [Recovery Formula Battle]",
-    "slug": "flyby-vs-fuller-health-complete-comparison-2025",
-    "excerpt": "Flyby vs Fuller Health After Party comparison. Two recovery formulas with DHM, milk thistle, NAC. Which works better for hangovers?",
-    "date": "2025-01-01",
-    "author": "DHM Guide Team",
-    "tags": [
-      "flyby",
-      "fuller-health",
-      "dhm-supplements",
-      "hangover-recovery",
-      "comparison"
     ],
     "image": "/images/flyby-recovery-review-2025-hero.webp",
     "readTime": 8
@@ -3502,5 +3394,249 @@
     ],
     "readTime": 12,
     "image": null
+  },
+  {
+    "id": "alcohol-and-nootropics-cognitive-enhancement-interactions-2025",
+    "slug": "alcohol-and-nootropics-cognitive-enhancement-interactions-2025",
+    "title": "Alcohol and Nootropics: Cognitive Enhancement Interactions (2025)",
+    "excerpt": "Complete guide to alcohol and nootropics cognitive enhancement interactions 2025. Learn science-backed strategies and expert recommendations for optimal health outcomes.",
+    "date": "2025-07-29",
+    "author": "DHM Guide Team",
+    "image": null,
+    "tags": [
+      "alcohol health",
+      "2025 health trends"
+    ],
+    "readTime": 28
+  },
+  {
+    "id": "alcohol-hypertension-blood-pressure-management-2025",
+    "slug": "alcohol-hypertension-blood-pressure-management-2025",
+    "title": "Alcohol and Hypertension: Blood Pressure Management (2025)",
+    "excerpt": "Alcohol consumption significantly impacts blood pressure regulation and cardiovascular health. Learn evidence-based strategies for managing hypertension while consuming alcohol, including DHM supplementation protocols and cardiovascular protection measures.",
+    "date": "2025-07-29",
+    "author": "DHM Guide Team",
+    "image": "/images/alcohol-diabetes-blood-sugar-management-guide-2025-hero.webp",
+    "tags": [
+      "hypertension",
+      "blood pressure",
+      "cardiovascular health",
+      "alcohol effects",
+      "DHM",
+      "heart health",
+      "alcohol management",
+      "medical conditions"
+    ],
+    "readTime": 18
+  },
+  {
+    "id": "alcohol-ketogenic-diet-ketosis-impact-analysis-2025",
+    "slug": "alcohol-ketogenic-diet-ketosis-impact-analysis-2025",
+    "title": "Alcohol and Ketogenic Diet: Ketosis Impact Analysis (2025)",
+    "excerpt": "Alcohol consumption can significantly disrupt ketosis and ketogenic diet effectiveness. Discover evidence-based strategies for managing alcohol intake while maintaining ketosis, including DHM supplementation protocols for keto dieters.",
+    "date": "2025-07-29",
+    "author": "DHM Guide Team",
+    "image": null,
+    "tags": [
+      "ketogenic diet",
+      "ketosis",
+      "alcohol metabolism",
+      "keto and alcohol",
+      "DHM",
+      "low carb diet",
+      "metabolic health",
+      "diet management"
+    ],
+    "readTime": 14
+  },
+  {
+    "id": "alcohol-kidney-disease-renal-function-impact-2025",
+    "slug": "alcohol-kidney-disease-renal-function-impact-2025",
+    "title": "Alcohol and Kidney Disease: Renal Function Impact (2025)",
+    "excerpt": "Comprehensive guide on alcohol's impact on kidney health. Learn scientific mechanisms, health risks, and evidence-based protection strategies including DHM benefits.",
+    "date": "2025-07-29",
+    "author": "DHM Guide Team",
+    "image": null,
+    "tags": [
+      "alcohol",
+      "kidney disease",
+      "renal function",
+      "chronic kidney disease",
+      "DHM",
+      "dihydromyricetin",
+      "nephrotoxicity",
+      "health"
+    ],
+    "readTime": 23
+  },
+  {
+    "id": "biohacking-alcohol-tolerance-science-based-strategies-2025",
+    "slug": "biohacking-alcohol-tolerance-science-based-strategies-2025",
+    "title": "Biohacking Your Alcohol Tolerance: Science-Based Strategies (2025)",
+    "excerpt": "In an era where personal optimization is paramount, the concept of \"biohacking\" has emerged as a powerful approach to fine-tuning our bodies and minds for peak performance. While often associated with enhancing cognitive function or physical prowess, biohacking principles can also be applied to a less conventional, yet equally relevant, aspect of modern life: alcohol consumption. This comprehensive guide delves into the science-backed strategies of biohacking your alcohol tolerance, focusing on performance optimization, the role of wearables, the benefits of cold therapy, and the crucial integration of Dihydromyricetin (DHM). As we navigate 2025, understanding how to responsibly manage and mitigate the effects of alcohol through informed choices and cutting-edge techniques becomes increasingly vital for overall well-being and sustained productivity. This article aims to provide actionable insights for those seeking to optimize their relationship with alcohol, ensuring that occasional indulgence aligns with a commitment to health and performance. We will explore the intricate mechanisms of alcohol metabolism, the factors influencing individual tolerance, and practical biohacking interventions that can help you navigate social occasions with greater control and less physiological impact.",
+    "date": "2025-07-28",
+    "author": "DHM Guide Team",
+    "image": "/images/biohacking-alcohol-tolerance-science-based-strategies-2025-hero.webp",
+    "tags": [
+      "biohacking alcohol",
+      "alcohol biohacking",
+      "metabolic flexibility alcohol"
+    ],
+    "readTime": 17
+  },
+  {
+    "id": "complete-hangover-science-hub-2025",
+    "slug": "complete-hangover-science-hub-2025",
+    "title": "Complete Hangover Science Hub: Your Ultimate Resource Guide",
+    "excerpt": "Ultimate hangover prevention resource. 50+ science-backed strategies, DHM guides, product reviews. Never suffer again. Shop top-rated supplements!",
+    "date": "2025-01-10",
+    "author": "DHM Guide Team",
+    "image": "/images/complete-hangover-science-hub-hero.webp",
+    "tags": [
+      "hangover hub",
+      "hangover science",
+      "DHM guide",
+      "alcohol recovery",
+      "hangover prevention",
+      "supplement comparison",
+      "liver health",
+      "hangover symptoms",
+      "drinking guide",
+      "wellness resource"
+    ],
+    "readTime": 8
+  },
+  {
+    "id": "dhm-availability-worldwide-guide-2025",
+    "slug": "dhm-availability-worldwide-guide-2025",
+    "title": "DHM Availability Worldwide: Complete Guide to Buying Dihydromyricetin Globally",
+    "excerpt": "Comprehensive guide to DHM availability worldwide. Learn where to buy dihydromyricetin in USA, UK, Canada, Australia, and Europe. Legal status, shipping options, and import regulations for every country.",
+    "date": "2025-01-10",
+    "author": "Global Health Research Team",
+    "image": null,
+    "tags": [
+      "dhm availability",
+      "worldwide guide",
+      "buy dhm",
+      "legal status",
+      "international shipping",
+      "dhm usa",
+      "dhm uk",
+      "dhm canada",
+      "dhm australia",
+      "dhm europe"
+    ],
+    "readTime": 15
+  },
+  {
+    "id": "dhm-safety-complete-guide-2025",
+    "slug": "dhm-safety-complete-guide-2025",
+    "title": "Is DHM Safe? Complete Safety Guide (Clinical Evidence & Research 2025)",
+    "excerpt": "DHM demonstrates exceptional safety with zero adverse events in 140 clinical trial participants. Complete evidence-based safety analysis covering liver health, drug interactions, contraindications, and long-term use.",
+    "date": "2025-11-09",
+    "author": "DHM Guide Team",
+    "image": null,
+    "tags": [
+      "dhm safety",
+      "dihydromyricetin safety",
+      "is dhm safe",
+      "dhm side effects",
+      "dhm drug interactions",
+      "dhm liver safety",
+      "dhm clinical trials",
+      "dhm contraindications"
+    ],
+    "readTime": 18
+  },
+  {
+    "id": "flyby-vs-fuller-health-complete-comparison",
+    "slug": "flyby-vs-fuller-health-complete-comparison",
+    "title": "Flyby vs Fuller Health: Complete 2025 Comparison [Recovery Formula Battle]",
+    "excerpt": "Complete supplement comparison guide. Which DHM brand works best? Side-by-side analysis + exclusive deals. Find your perfect match!",
+    "date": "2025-07-01",
+    "author": "DHM Guide Team",
+    "image": "/images/flyby-vs-fuller-health-hero.jpg",
+    "tags": [
+      "flyby",
+      "fuller-health",
+      "dhm-supplements",
+      "hangover-recovery",
+      "comparison"
+    ],
+    "readTime": 8
+  },
+  {
+    "id": "pregnant-women-and-alcohol-complete-fetal-impact-guide-2025",
+    "slug": "pregnant-women-and-alcohol-complete-fetal-impact-guide-2025",
+    "title": "Pregnant Women and Alcohol: Complete Fetal Impact Guide (2025)",
+    "excerpt": "Pregnancy is a transformative journey, a period of immense anticipation and careful consideration for the well-being of both mother and child. Among the myriad factors influencing fetal development, maternal alcohol consumption stands as a critical concern, capable of profoundly impacting the unborn child. Despite widespread awareness campaigns, alcohol use during pregnancy remains a significant public health issue globally, leading to a spectrum of preventable birth defects and developmental disabilities collectively known as Fetal Alcohol Spectrum Disorders (FASDs).",
+    "date": "2025-07-28",
+    "author": "DHM Guide Team",
+    "image": "/images/pregnant-women-and-alcohol-complete-fetal-impact-guide-2025-hero.webp",
+    "tags": [
+      "Pregnancy",
+      "Alcohol",
+      "Fetal Development",
+      "FASD",
+      "Public Health"
+    ],
+    "readTime": 20
+  },
+  {
+    "id": "preventative-health-strategies-regular-drinkers-2025",
+    "slug": "preventative-health-strategies-regular-drinkers-2025",
+    "title": "Preventative Health Strategies for Regular Drinkers (2025)",
+    "excerpt": "Discover science-backed preventative health strategies for regular drinkers. Learn about alcohol health screening, lifestyle interventions, and proactive approaches to maintain optimal well-being while enjoying alcohol responsibly.",
+    "date": "2025-01-28",
+    "author": "DHM Guide Team",
+    "image": "/images/preventative-health-strategies-regular-drinkers-2025-hero.webp",
+    "tags": [
+      "preventative alcohol health",
+      "alcohol health screening",
+      "lifestyle medicine alcohol",
+      "proactive health management",
+      "alcohol wellness",
+      "DHM benefits"
+    ],
+    "readTime": 15
+  },
+  {
+    "id": "shift-workers-alcohol-circadian-disruption-guide-2025",
+    "slug": "shift-workers-alcohol-circadian-disruption-guide-2025",
+    "title": "Shift Workers and Alcohol: Circadian Disruption Guide (2025)",
+    "excerpt": "Shift work disrupts natural circadian rhythms, making workers more vulnerable to alcohol's effects. Discover evidence-based strategies for managing alcohol consumption, protecting sleep cycles, and optimizing health for shift workers through DHM supplementation and circadian-aware practices.",
+    "date": "2025-07-29",
+    "author": "DHM Guide Team",
+    "image": "/images/smart-sleep-tech-alcohol-circadian-optimization-guide-2025-hero.webp",
+    "tags": [
+      "shift work",
+      "circadian rhythm",
+      "alcohol metabolism",
+      "sleep disruption",
+      "DHM",
+      "night shift health",
+      "alcohol safety",
+      "workplace wellness"
+    ],
+    "readTime": 12
+  },
+  {
+    "id": "ultimate-dhm-safety-guide-hub-2025",
+    "slug": "ultimate-dhm-safety-guide-hub-2025",
+    "title": "The Ultimate DHM Safety Guide Hub: Everything You Need to Know About Dihydromyricetin Safety",
+    "excerpt": "Your comprehensive resource hub for all DHM safety information. Access detailed guides on side effects, dosage, interactions, long-term use, and safety for specific populations.",
+    "date": "2025-01-10",
+    "author": "DHM Guide Team",
+    "image": null,
+    "tags": [
+      "dhm safety",
+      "comprehensive guide",
+      "safety hub",
+      "side effects",
+      "dosage",
+      "interactions",
+      "resource center"
+    ],
+    "readTime": 15
   }
 ]


### PR DESCRIPTION
Closes #84

Audit-first cleanup of \`src/newblog/data/metadata/index.json\`:

- **Removed 5 orphan entries** (metadata pointing to nonexistent posts; issue named 4, audit found 5th slug-rename casualty)
- **Added 13 reverse-orphans** (post files lacking metadata entries — would have been silently absent from blog listings)
- **Deduped 1 entry** (byte-identical duplicate)

**Net**: metadata count 190 → 197, exactly matches 197 posts on disk.

**New scripts** (CI-suitable, idempotent):
- \`scripts/audit-orphan-metadata.mjs\` — exit non-zero if drift detected
- \`scripts/fix-orphan-metadata.mjs\` — companion remediator

Re-running audit returns 0/0/0 (orphans/reverse-orphans/dupes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)