### PR TITLE
feat(reviews): hide 3 secondary columns on mobile comparison table (#117)

### DIFF
--- a/specs/issue-117-mobile-table-columns/tasks.md
+++ b/specs/issue-117-mobile-table-columns/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — Issue #117
+
+## T1 — Hide DHM column on mobile [Reviews.jsx]
+- [x] Edit `<th>DHM</th>` to add `hidden md:table-cell`.
+- [x] Edit corresponding `<td>` in `topProducts.map` row.
+
+## T2 — Hide Per Serving column on mobile [Reviews.jsx]
+- [x] Edit `<th>Per Serving</th>` to add `hidden md:table-cell`.
+- [x] Edit corresponding `<td>` in row.
+
+## T3 — Hide Reviews column on mobile [Reviews.jsx]
+- [x] Edit `<th>Reviews</th>` to add `hidden md:table-cell`.
+- [x] Edit corresponding `<td>` in row.
+
+## T4 — Verify build
+- [x] `npm run build` exits 0.
+- [x] `grep -lE 'hidden md:table-cell' dist/assets/*.js` returns ≥1.
+
+## T5 — Commit feature change
+- [x] Stage only `src/pages/Reviews.jsx`.
+- [x] Commit message: `feat(reviews): hide 3 secondary columns on mobile comparison table (#117)`
+- [x] Co-Authored-By trailer.
+
+## T6 — Commit spec scaffold
+- [x] Stage `specs/issue-117-mobile-table-columns/tasks.md` only.
+- [x] Commit message: `chore(spec): scaffold ralph spec artifacts for issue #117`
+- [x] Co-Authored-By trailer.
+
+## T7 — Stay on branch
+- [x] No push.
+- [x] No PR.

--- a/src/pages/Reviews.jsx
+++ b/src/pages/Reviews.jsx
@@ -655,11 +655,11 @@ export default function Reviews() {
                 <thead>
                   <tr className="bg-green-700 text-white">
                     <th className="py-3 px-4 text-left font-semibold">Brand</th>
-                    <th className="py-3 px-4 text-center font-semibold">DHM</th>
+                    <th className="py-3 px-4 text-center font-semibold hidden md:table-cell">DHM</th>
                     <th className="py-3 px-4 text-center font-semibold">Price</th>
-                    <th className="py-3 px-4 text-center font-semibold">Per Serving</th>
+                    <th className="py-3 px-4 text-center font-semibold hidden md:table-cell">Per Serving</th>
                     <th className="py-3 px-4 text-center font-semibold">Rating</th>
-                    <th className="py-3 px-4 text-center font-semibold">Reviews</th>
+                    <th className="py-3 px-4 text-center font-semibold hidden md:table-cell">Reviews</th>
                     <th className="py-3 px-4 text-center font-semibold">Score</th>
                     <th className="py-3 px-4 text-center font-semibold">Action</th>
                   </tr>
@@ -685,7 +685,7 @@ export default function Reviews() {
                           <div className="text-sm text-gray-600">{product.brand}</div>
                         </a>
                       </td>
-                      <td className="py-3 px-4 text-center font-medium text-green-700">{product.dhm}</td>
+                      <td className="py-3 px-4 text-center font-medium text-green-700 hidden md:table-cell">{product.dhm}</td>
                       <td className="py-3 px-4 text-center">
                         <a
                           href={product.affiliateLink}
@@ -698,7 +698,7 @@ export default function Reviews() {
                           {product.price}
                         </a>
                       </td>
-                      <td className="py-3 px-4 text-center">
+                      <td className="py-3 px-4 text-center hidden md:table-cell">
                         <a
                           href={product.affiliateLink}
                           target="_blank"
@@ -723,7 +723,7 @@ export default function Reviews() {
                           <span className="font-medium hover:underline">{product.rating}</span>
                         </a>
                       </td>
-                      <td className="py-3 px-4 text-center text-gray-700">{product.reviews.toLocaleString()}</td>
+                      <td className="py-3 px-4 text-center text-gray-700 hidden md:table-cell">{product.reviews.toLocaleString()}</td>
                       <td className="py-3 px-4 text-center">
                         <a
                           href={product.affiliateLink}


### PR DESCRIPTION
Closes #117 (alt solution; placement-first approach also already shipped via #278)

Adds \`hidden md:table-cell\` to 3 secondary columns in the comparison table at \`src/pages/Reviews.jsx\`:

- DHM mg
- Per Serving
- Reviews count

Mobile column count: **8 → 5** (Brand, Price, Rating, Score, Action remain visible at 360px).

**Out of scope**: card-layout fallback (overkill — placement-first via PR #278 already addresses the core friction). Compare.jsx structurally different and already responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)