### PR TITLE
feat(content): HowTo schema data on 4 Tier-1 hangover guides (#251)

### DIFF
--- a/specs/issue-251-howto-backfill/tasks.md
+++ b/specs/issue-251-howto-backfill/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — Issue #251
+
+## T1. Verify environment
+- [x] Confirm prerender script reads `post.howTo` (line 258, prerender-blog-posts-enhanced.js)
+- [x] Confirm helper `generateHowToSchema` in `src/utils/structuredDataHelpers.js`
+- [x] Confirm 2 existing posts have `howTo` field (dhm-dosage-guide-2025, when-to-take-dhm-timing-guide-2025)
+- [x] Capture exact key shape: `{name, description, totalTime, supply, steps:[{name,text}]}`
+
+## T2. Add howTo to how-to-cure-a-hangover-complete-science-guide.json
+- [ ] Read existing JSON
+- [ ] Append howTo block (6 steps: DHM dose, electrolyte hydration, antioxidants/B-complex, light food, headache management with NSAID-not-acetaminophen note, continued hydration)
+- [ ] Verify with `node -e "JSON.parse(...)"`
+
+## T3. Add howTo to how-to-get-rid-of-hangover-fast.json
+- [ ] Read existing JSON
+- [ ] Append howTo block (6 steps from post's "15-Minute Emergency Protocol")
+- [ ] Verify with `node -e "JSON.parse(...)"`
+
+## T4. Add howTo to hangover-headache-fast-relief-methods-2025.json
+- [ ] Read existing JSON
+- [ ] Append howTo block (5 steps from "15-Minute Emergency Hangover Headache Relief Protocol")
+- [ ] Verify with `node -e "JSON.parse(...)"`
+
+## T5. Add howTo to hangover-nausea-complete-guide-fast-stomach-relief-2025.json
+- [ ] Read existing JSON
+- [ ] Append howTo block (6 steps from "5-Minute Nausea Relief Technique" + Tier 1 remedies)
+- [ ] Verify with `node -e "JSON.parse(...)"`
+
+## T6. Build verification
+- [ ] Run `npm run build`
+- [ ] Build exits 0
+- [ ] All 4 dist HTML files emit `"@type":"HowTo"` (grep verification)
+
+## T7. Confirm scope
+- [ ] `git diff --name-only main` shows ONLY: 4 post JSONs + 4 spec files
+- [ ] `dhm-dosage-guide-2025.json` NOT modified
+- [ ] `when-to-take-dhm-timing-guide-2025.json` NOT modified
+
+## T8. Commit
+- [ ] `feat(content): add HowTo schema data to 4 Tier-1 hangover guide JSONs (#251)` — 4 post JSONs only
+- [ ] `chore(spec): scaffold ralph spec artifacts for issue #251` — 4 spec files only
+- [ ] Both commits include `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer
+- [ ] Stay on branch; do NOT push
+
+## Reset expectations note
+HowTo schema is ineligible for Google rich-result surfaces post-Sept 2023
+for YMYL/health content. Real ROI is **AI Overview / LLM grounding**, not
+SERP CTR. PRD's "+20-35% CTR" claim should be reset to 0–5%.

--- a/src/newblog/data/posts/hangover-headache-fast-relief-methods-2025.json
+++ b/src/newblog/data/posts/hangover-headache-fast-relief-methods-2025.json
@@ -23,5 +23,40 @@
     "hangover-nausea-complete-guide-fast-stomach-relief-2025",
     "cold-therapy-alcohol-recovery-guide-2025",
     "alcohol-headache-why-it-happens-how-to-prevent-2025"
-  ]
+  ],
+  "howTo": {
+    "name": "How to Relieve a Hangover Headache Fast",
+    "description": "Fast hangover-headache relief protocol combining electrolyte hydration, dark-room rest, pressure-point relief, and targeted supplementation — drawn from this guide's 15-minute emergency headache protocol.",
+    "totalTime": "PT15M",
+    "supply": [
+      "Room-temperature water with sea salt (16 oz + 1/4 tsp)",
+      "Magnesium glycinate (400mg)",
+      "Cold compress",
+      "Ibuprofen (400-600mg, taken with food)",
+      "B-complex vitamin",
+      "DHM supplement (300mg, optional)"
+    ],
+    "steps": [
+      {
+        "name": "Rehydrate with electrolyte water immediately",
+        "text": "Drink 16 oz of room-temperature water with 1/4 teaspoon of sea salt within the first 3 minutes. Avoid ice-cold water, which can trigger nausea. Sodium replacement is what makes simple water actually rehydrate brain tissue at this stage."
+      },
+      {
+        "name": "Move to a dark, quiet room and rest",
+        "text": "Light and noise sensitivity are amplified during a hangover headache because alcohol disrupts neurotransmitter balance. Close blinds, turn off screens, and lie down with your head slightly elevated. Even 5-10 minutes of true sensory rest helps."
+      },
+      {
+        "name": "Apply a cold compress and use pressure-point relief",
+        "text": "Place a cold compress on your forehead and temples. Apply gentle pressure to the LI-4 acupressure point (the web between thumb and index finger) for 60 seconds, then massage your temples in slow circles. Both are low-risk supportive techniques."
+      },
+      {
+        "name": "Take 400mg magnesium glycinate",
+        "text": "Alcohol depletes magnesium, which is directly involved in nerve excitability and headache pathways. 400mg of magnesium glycinate is well tolerated even when the stomach is sensitive and supports headache relief without sedation."
+      },
+      {
+        "name": "Use ibuprofen for pain — never acetaminophen with alcohol in your system",
+        "text": "If pain is severe, take 400-600mg ibuprofen with food. Critical safety note: do NOT use acetaminophen (Tylenol) while alcohol is still being metabolized — it sharply increases the risk of liver damage. Add a B-complex vitamin and an optional 300mg DHM dose to support recovery."
+      }
+    ]
+  }
 }

--- a/src/newblog/data/posts/hangover-nausea-complete-guide-fast-stomach-relief-2025.json
+++ b/src/newblog/data/posts/hangover-nausea-complete-guide-fast-stomach-relief-2025.json
@@ -25,5 +25,43 @@
     "good-morning-hangover-pills-review-2025",
     "hangover-headache-fast-relief-methods-2025",
     "activated-charcoal-hangover"
-  ]
+  ],
+  "howTo": {
+    "name": "How to Relieve Hangover Nausea Fast",
+    "description": "Practical nausea-relief protocol using positional posture, controlled hydration, ginger, B6, and acupressure — extracted from this guide's 5-minute relief technique and Tier 1 most-effective remedies.",
+    "totalTime": "PT30M",
+    "supply": [
+      "Room-temperature water (small amounts)",
+      "Fresh ginger or ginger tea (1 tablespoon grated, or 250mg ginger chews)",
+      "Vitamin B6 (25-50mg)",
+      "Peppermint tea (optional)",
+      "Electrolyte powder (1/4 tsp salt + 1 tsp sugar in 8 oz water)"
+    ],
+    "steps": [
+      {
+        "name": "Sit upright and sip room-temperature water slowly",
+        "text": "Prop yourself at roughly 45 degrees — do not lie flat. Sip 2-3 ounces of room-temperature water every 60 seconds. Cold water can trigger stomach spasms; large gulps overwhelm a stomach that already empties slowly after alcohol."
+      },
+      {
+        "name": "Apply P6 acupressure for nausea",
+        "text": "Press the P6 point (three finger-widths below the inside of your wrist, between the two tendons) firmly for 2-3 minutes per wrist. Repeat hourly as needed. P6 stimulation is one of the most evidence-supported non-pharmaceutical anti-nausea techniques."
+      },
+      {
+        "name": "Use ginger to settle the stomach",
+        "text": "Brew ginger tea (1 tablespoon grated fresh ginger steeped 5-10 minutes), or take 250mg ginger chews. Gingerols help block nausea receptors. Stay under 4 grams of ginger total per day."
+      },
+      {
+        "name": "Take 25-50mg of vitamin B6",
+        "text": "Vitamin B6 reduces nausea via neurotransmitter regulation. A single 25-50mg dose typically works within 30-60 minutes. Do not exceed 100mg in 24 hours."
+      },
+      {
+        "name": "Switch to controlled electrolyte rehydration",
+        "text": "Once initial nausea eases, mix 1/4 teaspoon salt and 1 teaspoon sugar in 8 ounces of room-temperature water and sip slowly over 30 minutes. The sodium and small amount of glucose dramatically improve fluid absorption compared with plain water."
+      },
+      {
+        "name": "Reintroduce easy-to-digest food",
+        "text": "When nausea is manageable, introduce plain white rice, banana, plain toast, or clear bone broth. Avoid greasy, spicy, citrus, dairy, or coffee for at least the next several hours — all of these worsen stomach irritation in this state."
+      }
+    ]
+  }
 }

--- a/src/newblog/data/posts/how-to-cure-a-hangover-complete-science-guide.json
+++ b/src/newblog/data/posts/how-to-cure-a-hangover-complete-science-guide.json
@@ -24,5 +24,44 @@
     "dhm-science-explained",
     "dhm-japanese-raisin-tree-complete-guide",
     "dhm-randomized-controlled-trials"
-  ]
+  ],
+  "howTo": {
+    "name": "How to Manage Hangover Symptoms After Drinking",
+    "description": "Science-based protocol to manage hangover symptoms using DHM, electrolyte rehydration, antioxidant support, and safe pain relief — extracted from this guide's Tier 1 and Tier 2 recovery content.",
+    "totalTime": "PT1H",
+    "supply": [
+      "DHM supplement (400-600mg)",
+      "Electrolyte solution (20-24 oz)",
+      "Vitamin C (1000-2000mg)",
+      "B-complex vitamin (with B1, B6, B12)",
+      "Light digestible food (toast, banana, eggs)",
+      "Ibuprofen (200-400mg, optional)"
+    ],
+    "steps": [
+      {
+        "name": "Take a recovery dose of DHM with water",
+        "text": "Upon waking with hangover symptoms, take 400-600mg of DHM with a full glass of water. DHM supports the liver enzymes (ADH and ALDH) that clear acetaldehyde, the toxic alcohol byproduct most directly tied to symptoms."
+      },
+      {
+        "name": "Rehydrate with an electrolyte solution",
+        "text": "Drink 20-24 ounces of an electrolyte solution within the first 30 minutes. Plain water alone is insufficient — sodium, potassium, and magnesium replacement is what restores cellular fluid balance after alcohol's diuretic effects."
+      },
+      {
+        "name": "Add antioxidant and B-vitamin support",
+        "text": "Take 1000-2000mg of vitamin C plus a B-complex vitamin (B1 thiamine, B6, B12). B-vitamins are depleted during alcohol metabolism and are essential for restoring normal neurological function. Take with food to prevent stomach irritation."
+      },
+      {
+        "name": "Eat a small, easily digestible meal",
+        "text": "Once nausea allows, eat simple carbohydrates and potassium-rich foods: toast, plain crackers, bananas, or eggs. This stabilizes blood sugar and replaces the potassium lost overnight. Avoid greasy or spicy food, which delays gastric emptying."
+      },
+      {
+        "name": "Use ibuprofen for headache — never acetaminophen",
+        "text": "For severe headache, ibuprofen 200-400mg taken with food is appropriate once alcohol has fully cleared the system. Do NOT use acetaminophen (Tylenol) — combining it with residual alcohol metabolites significantly raises the risk of liver toxicity."
+      },
+      {
+        "name": "Continue hydration and rest through the day",
+        "text": "Sip water or electrolyte solution every 20-30 minutes for the next several hours and prioritize rest. Most symptoms improve within 4-6 hours when DHM and rehydration are combined; full recovery typically occurs within 12-18 hours."
+      }
+    ]
+  }
 }

--- a/src/newblog/data/posts/how-to-get-rid-of-hangover-fast.json
+++ b/src/newblog/data/posts/how-to-get-rid-of-hangover-fast.json
@@ -64,5 +64,44 @@
       "question": "Is the 15-minute hangover cure safe?",
       "answer": "Yes, the 15-minute hangover cure using DHM is safe when used occasionally. DHM has been tested in clinical trials at doses up to 1000mg without adverse effects. However, emergency dosing should not exceed once per week and is intended for severe hangover situations only."
     }
-  ]
+  ],
+  "howTo": {
+    "name": "How to Get Fast Hangover Relief in Under 60 Minutes",
+    "description": "Emergency hangover relief protocol using DHM, electrolytes, NAC, and targeted supplements — adapted directly from this guide's 15-minute emergency protocol for moderate-to-severe hangover symptoms.",
+    "totalTime": "PT1H",
+    "supply": [
+      "DHM supplement (800-1000mg for emergency dosing)",
+      "Electrolyte solution with glucose (20 oz)",
+      "N-acetylcysteine / NAC (600mg)",
+      "Vitamin C (1000mg)",
+      "B-complex vitamins (high-potency, especially B1, B6, B12)",
+      "Magnesium glycinate (400mg)"
+    ],
+    "steps": [
+      {
+        "name": "Take an emergency DHM dose immediately on waking",
+        "text": "Take 800mg of DHM with water within minutes of waking. Higher emergency dosing helps accelerate clearance of remaining acetaldehyde and supports recovery of GABA receptor function — both of which drive the worst morning symptoms."
+      },
+      {
+        "name": "Drink 20 oz of electrolyte solution with glucose",
+        "text": "Consume an electrolyte drink containing sodium, potassium, and a small amount of glucose. Glucose helps with stomach absorption and stabilizes blood sugar. Aim to finish within 5 minutes if your stomach tolerates it; sip slowly otherwise."
+      },
+      {
+        "name": "Add NAC, vitamin C, and B-complex",
+        "text": "Take 600mg N-acetylcysteine (supports glutathione for liver antioxidant defense), 1000mg vitamin C, and a high-potency B-complex. Take all three with food or your electrolyte drink to prevent stomach irritation from the supplements."
+      },
+      {
+        "name": "Take 400mg magnesium glycinate",
+        "text": "Magnesium is depleted by alcohol and is directly involved in nerve function and headache pathways. Magnesium glycinate is gentler on the stomach than oxide or citrate forms and is well tolerated when nauseated."
+      },
+      {
+        "name": "Eat light, easily digestible protein and get fresh air",
+        "text": "After 15-30 minutes, eat a small protein-and-carb meal (eggs, toast, banana). Avoid greasy or spicy food. Step outside or open windows — natural light and fresh air help reset cortisol rhythm and reduce fatigue."
+      },
+      {
+        "name": "Reassess after 2 hours and redose DHM if needed",
+        "text": "Most symptoms should significantly improve within 60-90 minutes. If symptoms persist, take an additional 300mg DHM and continue hydration. If vomiting prevents fluid retention beyond 12 hours, or you experience confusion or dizziness on standing, seek medical care."
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Closes #251 (scoped to 4 Tier-1 posts; emission code already wired)

Adds \`howTo\` JSON field to 4 Tier-1 guide posts (emission lives in \`scripts/prerender-blog-posts-enhanced.js:258-272\` and was already wired):

- \`how-to-cure-a-hangover-complete-science-guide\` — 6 steps, PT1H
- \`how-to-get-rid-of-hangover-fast\` — 6 steps, PT1H
- \`hangover-headache-fast-relief-methods-2025\` — 5 steps, PT15M
- \`hangover-nausea-complete-guide-fast-stomach-relief-2025\` — 6 steps, PT30M

**Conservative health language**: no "cure" / "guarantee"; uses "manage", "relieve", "support recovery".

**Reset expectations**: Google removed HowTo rich-result eligibility for medical/health content in Sept 2023. Real ROI is now AI Overviews / LLM grounding (Perplexity, ChatGPT, Claude.ai citation), NOT SERP CTR. Documented in spec \`research.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)