### PR TITLE
feat(reviews): replace select filter with Best-For button row (#209)

### DIFF
--- a/specs/issue-209-best-for-buttons/design.md
+++ b/specs/issue-209-best-for-buttons/design.md
@@ -1,0 +1,104 @@
+# Design — Issue #209
+
+## Approach
+
+Pure inline change inside `src/pages/Reviews.jsx`. No new files, no new
+components, no new dependencies.
+
+## Data shape
+
+Replace existing `filterOptions` (category-based) with:
+
+```jsx
+const bestForFilters = [
+  { id: 'all',     label: 'All Products',     match: null },
+  { id: 'overall', label: 'Best Overall',     match: (p) => /\b(best|trusted)\b/i.test(p.bestFor) },
+  { id: 'value',   label: 'Best Value',       match: (p) => /value/i.test(p.bestFor) },
+  { id: 'heavy',   label: 'Heavy Drinkers',   match: (p) => /(party|weekend|high-performer)/i.test(p.bestFor) },
+  { id: 'health',  label: 'Health-Conscious', match: (p) => /(health|liver)/i.test(p.bestFor) },
+]
+```
+
+`filterBy` state default stays `'all'`.
+
+Filter predicate becomes:
+
+```jsx
+const activeFilter = bestForFilters.find(f => f.id === filterBy)
+const filteredProducts = activeFilter?.match
+  ? topProducts.filter(activeFilter.match)
+  : topProducts
+```
+
+## Markup
+
+Replace the existing block:
+
+```jsx
+<select value={filterBy} ...>
+  {filterOptions.map(...)}
+</select>
+```
+
+with:
+
+```jsx
+<div className="flex flex-wrap gap-2">
+  {bestForFilters.map(f => {
+    const active = filterBy === f.id
+    return (
+      <button
+        key={f.id}
+        type="button"
+        onClick={() => handleFilterClick(f.id)}
+        aria-pressed={active}
+        className={cn(
+          'min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+          active
+            ? 'bg-orange-500 text-white border border-orange-500 shadow-sm'
+            : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+        )}
+      >
+        {f.label}
+      </button>
+    )
+  })}
+</div>
+```
+
+`cn` from `@/lib/utils` is the project's standard class joiner (already
+used by Button component). If a stricter no-import policy applies, use
+template literal joining instead.
+
+## Toggle behavior
+
+```jsx
+const handleFilterClick = (id) => {
+  // Same button clicked twice → clear back to "all"
+  const next = (filterBy === id && id !== 'all') ? 'all' : id
+  setFilterBy(next)
+  trackEvent('filter_clicked', { filter_value: next })
+}
+```
+
+## Tracking
+
+`trackEvent` already exists in `src/lib/posthog.js` (line 109). Add it to
+the existing import line at the top of `Reviews.jsx`:
+
+```jsx
+import { trackElementClick, trackEvent } from '../lib/posthog'
+```
+
+Event: `filter_clicked`. Payload: `{ filter_value: '<id>' }` where `<id>`
+is one of `all | overall | value | heavy | health`. The standard
+`page_path`, `timestamp` etc. are added automatically by `trackEvent`.
+
+## Risks / considerations
+
+- The native `<select>` was wider than a button row. The wrapping flex
+  container handles narrow viewports (`flex-wrap` + `gap-2`).
+- If a future product is added whose `bestFor` matches none of the
+  predicates, it only appears under "All Products". Acceptable.
+- The existing `category` field is left in place. Other code (if any)
+  that reads `product.category` is unaffected.

--- a/specs/issue-209-best-for-buttons/requirements.md
+++ b/specs/issue-209-best-for-buttons/requirements.md
@@ -1,0 +1,54 @@
+# Requirements — Issue #209
+
+## Acceptance criteria (this branch)
+
+- [ ] The native `<select>` for filtering at `src/pages/Reviews.jsx:606-614`
+      is replaced by a horizontal flex of buttons (one per filter).
+- [ ] Five filter buttons render in this order: "All Products",
+      "Best Overall", "Best Value", "Heavy Drinkers", "Health-Conscious".
+- [ ] Active button has visually distinct styling (orange background +
+      white text, matching the page's existing orange-500 system).
+- [ ] Inactive buttons are styled as outlined / muted.
+- [ ] Clicking a filter button sets it as active. Clicking the active
+      button again clears the filter back to "All Products" (toggle).
+- [ ] Each filter applies a predicate against `product.bestFor`
+      (case-insensitive substring match) — see `research.md` for the
+      term list per filter.
+- [ ] Filter buttons wrap on narrow viewports (`flex-wrap`).
+- [ ] Each button has `min-h-[44px]` minimum touch target.
+- [ ] Each button click fires `trackEvent('filter_clicked', { filter_value })`
+      via existing `trackEvent` (or equivalent) from `../lib/posthog`.
+- [ ] No new dependencies introduced.
+- [ ] `npm run build` succeeds.
+- [ ] Built dist contains the literal labels "Best Overall", "Best Value",
+      "Heavy Drinkers" (verified via grep over `dist/assets/*.js`).
+- [ ] Two commits with Co-Authored-By trailer:
+      1. `feat(reviews): replace select filter with Best-For button row (#209)`
+      2. `chore(spec): scaffold ralph spec artifacts for issue #209`
+- [ ] No push, no PR.
+
+## In-scope for this branch
+
+1. Edit `src/pages/Reviews.jsx`:
+   - Replace `filterOptions` array shape (categories) with a new
+     `bestForFilters` array of `{ id, label, match }` where `match` is a
+     predicate function over `product.bestFor`.
+   - Replace `<select>...</select>` block with a button row.
+   - Update the filter logic at line 420-421 to use the predicate from
+     the active filter.
+   - Add `trackEvent` import from `../lib/posthog`.
+   - Wire `onClick` handlers that toggle the active filter and fire
+     the PostHog event.
+2. Add scaffolded spec artifacts under
+   `specs/issue-209-best-for-buttons/`.
+3. Verify with `npm run build`, grep dist for the new labels.
+4. Two clean commits on local branch.
+
+## Out of scope
+
+- Changes to Compare.jsx or any other page.
+- Changes to the sort `<select>` (only the filter is replaced).
+- Adding new badges to product data.
+- Changing the `category` field — kept for any other consumers.
+- Match-count display (issue suggested but not required for this branch).
+- Filter animations.

--- a/specs/issue-209-best-for-buttons/research.md
+++ b/specs/issue-209-best-for-buttons/research.md
@@ -1,0 +1,83 @@
+# Research — Issue #209
+
+## Issue summary
+
+Replace the existing `<select>` filter at `src/pages/Reviews.jsx:606-614`
+with a horizontal "Best For" button row that lets users one-click filter
+products by use-case.
+
+Issue link: kavanaghpatrick/dhm-guide-website#209
+
+## Existing state
+
+- `src/pages/Reviews.jsx` defines `topProducts` (10 items) at line 103.
+  Each product has both a `category` field (`premium`, `budget`,
+  `comprehensive`, `convenience`) and a free-form `bestFor` string.
+- `filterBy` state at line 35 is currently a category string and the
+  filter predicate at line 420-421 compares `product.category === filterBy`.
+- `filterOptions` at line 405-411 uses category values, rendered into a
+  native `<select>` at line 606-614.
+- `Filter` icon from `lucide-react` is already imported (line 18).
+- `trackElementClick` from `../lib/posthog` is already imported (line 29)
+  and used 3x on the page.
+- Tailwind v4, no CSS modules. Existing button conventions on this page
+  use `rounded-lg`, `min-h-[44px]` or `min-h-[48px]`, and the orange
+  gradient family (`from-orange-500 to-orange-600`).
+
+## bestFor strings (raw)
+
+| Product | bestFor | category |
+|---------|---------|----------|
+| No Days Wasted | "Weekend warriors who want the best" | premium |
+| Double Wood | "Value hunters who want pure DHM" | budget |
+| Toniiq Ease | "Health-conscious drinkers who protect their liver" | comprehensive |
+| NusaPure | "Bulk buyers who want maximum value" | budget |
+| Cheers Restore | "Social drinkers who want a trusted brand" | premium |
+| Flyby Recovery | "Party people who need serious protection" | comprehensive |
+| Good Morning | "Travelers needing portable protection" | convenience |
+| DHM1000 | "High-performers who want max potency" | premium |
+| Fuller Health | "Trendsetters who appreciate celebrity picks" | premium |
+| DHM Depot | "Research-driven buyers who trust reviews" | premium |
+
+## Mapping decision
+
+Issue body suggests four buckets — "Best Overall", "Best Value",
+"Heavy Drinkers", "Budget Pick". The free-form `bestFor` strings do not
+cluster cleanly into those four labels, so we use case-insensitive
+substring matching on `bestFor` (per ultrathink scope note "case-insensitive
+substring match is fine if labels don't perfectly align").
+
+Filter buttons → predicate (matches if `bestFor` substring contains any term):
+
+- **All Products** → no predicate (clears filter)
+- **Best Overall** → `bestFor` contains `"best"` or `"trusted"`
+  → No Days Wasted (Weekend warriors who want the **best**),
+    Cheers (Social drinkers who want a **trusted** brand)
+- **Best Value** → `bestFor` contains `"value"`
+  → Double Wood (**Value** hunters), NusaPure (Bulk buyers who want
+    maximum **value**)
+- **Heavy Drinkers** → `bestFor` contains `"party"` or `"weekend"` or
+  `"high-performer"`
+  → No Days Wasted (**Weekend** warriors), Flyby (**Party** people),
+    DHM1000 (**High-performer**s)
+- **Health-Conscious** → `bestFor` contains `"health"` or `"liver"`
+  → Toniiq (**Health**-conscious drinkers who protect their **liver**)
+
+This gives every button at least one match (no empty states) and
+respects what the data actually says without inventing badges.
+
+## PostHog event
+
+Per spec: fire `filter_clicked` event on each click with payload
+`{ filter_value: '<button id>' }`. Use existing `trackEvent` import from
+`src/lib/posthog.js` rather than `trackElementClick`, because the spec
+asks for a custom event name not the generic `element_clicked`.
+
+## Out of scope
+
+- No schema changes to product data.
+- No changes to Compare.jsx or any other page.
+- No changes to the sort `<select>` (only the filter `<select>` is replaced).
+- No animations, loading states, or scroll-position management beyond
+  what React already does.
+- No multi-select.

--- a/specs/issue-209-best-for-buttons/tasks.md
+++ b/specs/issue-209-best-for-buttons/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — Issue #209
+
+## Implementation tasks
+
+- [x] T1. Read `Reviews.jsx`, capture `bestFor` strings for all 10 products
+      (research.md table).
+- [x] T2. Decide filter buttons + substring predicates (research.md).
+- [ ] T3. Edit `src/pages/Reviews.jsx`:
+  - [ ] T3.1. Add `trackEvent` to the existing posthog import.
+  - [ ] T3.2. Replace `filterOptions` array with `bestForFilters` array
+              (5 entries with `id`, `label`, `match` predicate).
+  - [ ] T3.3. Update `filteredProducts` definition to use the active
+              filter's `match` predicate.
+  - [ ] T3.4. Replace the `<select>` filter block with a `flex-wrap`
+              button row, including active/inactive variants and
+              `min-h-[44px]` touch target.
+  - [ ] T3.5. Add `handleFilterClick(id)` toggle handler that flips back
+              to `'all'` when the same non-`'all'` button is clicked
+              twice, and fires `trackEvent('filter_clicked',
+              { filter_value })`.
+- [ ] T4. Run `npm run build`. Must succeed.
+- [ ] T5. Verify dist contains the new labels:
+      `grep -oE '(Best Overall|Best Value|Heavy Drinkers)' dist/assets/*.js | head`
+- [ ] T6. Commit Reviews.jsx as
+      `feat(reviews): replace select filter with Best-For button row (#209)`
+      with Co-Authored-By trailer.
+- [ ] T7. Commit specs/ as
+      `chore(spec): scaffold ralph spec artifacts for issue #209`
+      with Co-Authored-By trailer.
+- [ ] T8. Verify branch state (`git status`, `git log --oneline -3`).
+      Stay on branch — no push, no PR.
+
+## Done definition
+
+- Build green.
+- Dist grep finds the labels.
+- Two commits exist on the local branch with the exact subjects above.
+- No other files modified or staged outside this issue's scope.

--- a/src/pages/Reviews.jsx
+++ b/src/pages/Reviews.jsx
@@ -26,7 +26,7 @@ import {
   Trophy
 } from 'lucide-react'
 import { useFeatureFlag } from '../hooks/useFeatureFlag'
-import { trackElementClick } from '../lib/posthog'
+import { trackElementClick, trackEvent } from '../lib/posthog'
 import topProductsData from '../data/topProducts.json'
 
 export default function Reviews() {
@@ -105,13 +105,23 @@ export default function Reviews() {
   // that ItemList schema on /reviews stays in sync with visible content.
   const topProducts = topProductsData
 
-  const filterOptions = [
-    { value: 'all', label: 'All Products' },
-    { value: 'premium', label: 'Premium' },
-    { value: 'budget', label: 'Budget' },
-    { value: 'comprehensive', label: 'Comprehensive' },
-    { value: 'convenience', label: 'Convenience' }
+  // Issue #209: "Best For" quick-filter buttons. Each filter applies a
+  // case-insensitive substring predicate to product.bestFor — see
+  // specs/issue-209-best-for-buttons/research.md for the mapping rationale.
+  const bestForFilters = [
+    { id: 'all', label: 'All Products', match: null },
+    { id: 'overall', label: 'Best Overall', match: (p) => /\b(best|trusted)\b/i.test(p.bestFor) },
+    { id: 'value', label: 'Best Value', match: (p) => /value/i.test(p.bestFor) },
+    { id: 'heavy', label: 'Heavy Drinkers', match: (p) => /(party|weekend|high-performer)/i.test(p.bestFor) },
+    { id: 'health', label: 'Health-Conscious', match: (p) => /(health|liver)/i.test(p.bestFor) }
   ]
+
+  const handleFilterClick = (id) => {
+    // Toggle: clicking the active non-default button clears back to 'all'
+    const next = (filterBy === id && id !== 'all') ? 'all' : id
+    setFilterBy(next)
+    trackEvent('filter_clicked', { filter_value: next })
+  }
 
   const sortOptions = [
     { value: 'rating', label: 'Highest Rated' },
@@ -120,9 +130,10 @@ export default function Reviews() {
     { value: 'reviews', label: 'Most Reviews' }
   ]
 
-  const filteredProducts = topProducts.filter(product => 
-    filterBy === 'all' || product.category === filterBy
-  )
+  const activeFilter = bestForFilters.find(f => f.id === filterBy)
+  const filteredProducts = activeFilter?.match
+    ? topProducts.filter(activeFilter.match)
+    : topProducts
 
   const sortedProducts = [...filteredProducts].sort((a, b) => {
     switch (sortBy) {
@@ -303,18 +314,30 @@ export default function Reviews() {
       <section className="py-4 md:py-6 px-4 bg-white">
         <div className="container mx-auto max-w-6xl">
           <div className="flex flex-col md:flex-row gap-4 items-center justify-between mb-4 md:mb-6">
-            <div className="flex items-center space-x-4">
-              <Filter className="w-5 h-5 text-gray-600" />
-              <span className="font-medium text-gray-900">Filter by:</span>
-              <select 
-                value={filterBy} 
-                onChange={(e) => setFilterBy(e.target.value)}
-                className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
-              >
-                {filterOptions.map(option => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
+            <div className="flex flex-wrap items-center gap-2 md:gap-3">
+              <div className="flex items-center gap-2 mr-1">
+                <Filter className="w-5 h-5 text-gray-600" />
+                <span className="font-medium text-gray-900">Best For:</span>
+              </div>
+              {bestForFilters.map(f => {
+                const active = filterBy === f.id
+                return (
+                  <button
+                    key={f.id}
+                    type="button"
+                    onClick={() => handleFilterClick(f.id)}
+                    aria-pressed={active}
+                    data-filter-id={f.id}
+                    className={`min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium transition-colors border ${
+                      active
+                        ? 'bg-orange-500 text-white border-orange-500 shadow-sm hover:bg-orange-600'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400'
+                    }`}
+                  >
+                    {f.label}
+                  </button>
+                )
+              })}
             </div>
             
             <div className="flex items-center space-x-4">


### PR DESCRIPTION
Closes #209 (partial — match-count badges + DHM Depot regex deferred per #345 redirect)

Replaces \`<select>\` filter with horizontal button group on /reviews:

- 5 buttons: All Products, Best Overall, Best Value, Heavy Drinkers, Health-Conscious
- Substring matching against existing \`bestFor\` strings on each product
- PostHog \`filter_clicked\` event with \`{ filter_value: <id> }\` payload
- Active state styling matches site's orange-500 CTA system
- Mobile-friendly (flex-wrap), 44px touch targets, aria-pressed for a11y

**Deferred** (per #345 A3+A4 redirect note):
- Match-count display per button
- "trust" regex expansion to surface DHM Depot under Best Overall

These can be amended onto this branch's spirit via a follow-up PR or filed as #345-followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)