### PR TITLE
ci: mass-edit moratorium guardrail (closes #366)

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -34,3 +34,20 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm run build
+
+  mass-edit-check:
+    name: Mass-edit moratorium check (#366, expires 2026-07-15)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check post JSON modification count
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-mass-edit.mjs --base origin/${{ github.base_ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -588,6 +588,22 @@ This ensures spec history is reviewable in PR while runtime artifacts stay out o
 
 ---
 
+## Mass-Edit Moratorium Policy
+
+**Active until 2026-07-15** (issue #366).
+
+Per the DCNI investigation (#362): mass-edits across many post JSONs trigger Google recrawl waves which re-evaluate posts against the current quality bar. PR #243 (147 files) and #246 (197 files) caused measurable DCNI growth. The moratorium prevents recurrence during recovery.
+
+**The rule**: PRs modifying >20 files in `src/newblog/data/posts/` will FAIL CI.
+
+**Escape hatch**: Add `[mass-edit-allowed]` to PR description with rationale (e.g., "corpus restore from backup", "post-moratorium realignment").
+
+**At 2026-07-15**: remove this section, the workflow job, and `scripts/check-mass-edit.mjs`.
+
+**Tracking**: weekly DCNI count via GSC. See issue #366.
+
+---
+
 ## ⚠️ Red Flags (STOP and Simplify)
 
 If you find yourself:

--- a/scripts/check-mass-edit.mjs
+++ b/scripts/check-mass-edit.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * check-mass-edit.mjs
+ *
+ * CI guardrail for the mass-edit moratorium (issue #366, expires 2026-07-15).
+ * Fails if a PR modifies > THRESHOLD post JSONs without [mass-edit-allowed]
+ * in the PR description.
+ *
+ * Mirrors scripts/verify-z-classes.mjs precedent: Node stdlib only, zero deps,
+ * binary exit code, multi-line failure message linking to root cause.
+ *
+ * Usage:
+ *   node scripts/check-mass-edit.mjs                                  # default base=origin/main, threshold=20
+ *   node scripts/check-mass-edit.mjs --base HEAD~5                    # local testing
+ *   node scripts/check-mass-edit.mjs --pr-body "..." --threshold 10   # CLI override
+ *
+ * Refs: https://github.com/kavanaghpatrick/dhm-guide-website/issues/366
+ *       CLAUDE.md "Mass-Edit Moratorium Policy" section
+ */
+
+import { execSync } from 'node:child_process';
+
+// Argv parsing (stdlib only)
+const args = process.argv.slice(2);
+const getFlag = (name, def) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? def : args[i + 1];
+};
+
+const BASE = getFlag('base', 'origin/main');
+const THRESHOLD = parseInt(getFlag('threshold', '20'), 10);
+const PR_BODY = getFlag('pr-body', process.env.PR_BODY || '');
+const OVERRIDE_TAG = '[mass-edit-allowed]';
+const POST_RE = /^src\/newblog\/data\/posts\/[^/]+\.json$/;
+
+// Determine modified post JSONs
+let changed;
+try {
+  changed = execSync(`git diff --name-only ${BASE}...HEAD`, { encoding: 'utf8' })
+    .split('\n')
+    .filter(f => POST_RE.test(f));
+} catch (e) {
+  console.error(`[check-mass-edit] Failed to compute diff against ${BASE}: ${e.message}`);
+  console.error('In CI, ensure actions/checkout uses fetch-depth: 0');
+  process.exit(2);
+}
+
+const count = changed.length;
+const hasOverride = PR_BODY.includes(OVERRIDE_TAG);
+
+if (count <= THRESHOLD) {
+  console.log(`[check-mass-edit] OK: ${count} post JSON(s) modified (threshold ${THRESHOLD})`);
+  process.exit(0);
+}
+
+if (hasOverride) {
+  console.log(`[check-mass-edit] OK (override): ${count} files modified, PR body contains ${OVERRIDE_TAG}`);
+  process.exit(0);
+}
+
+// Failure — clear, actionable error message
+console.error(`\n[check-mass-edit] FAIL — mass-edit moratorium violation`);
+console.error(`  Modified ${count} post JSONs in src/newblog/data/posts/ (threshold: ${THRESHOLD})`);
+console.error(`  This may trigger a Google recrawl wave during DCNI recovery`);
+console.error(`  (issue #366, expires 2026-07-15)`);
+console.error(``);
+console.error(`  Files (first 10):`);
+changed.slice(0, 10).forEach(f => console.error(`    ${f}`));
+if (count > 10) console.error(`    ... and ${count - 10} more`);
+console.error(``);
+console.error(`  To override (with rationale), add to PR description:`);
+console.error(`    ${OVERRIDE_TAG}`);
+console.error(``);
+console.error(`  Background: https://github.com/kavanaghpatrick/dhm-guide-website/issues/366`);
+console.error(`  Policy: CLAUDE.md "Mass-Edit Moratorium Policy" section\n`);
+process.exit(1);

--- a/specs/issue-366-moratorium/design.md
+++ b/specs/issue-366-moratorium/design.md
@@ -1,0 +1,354 @@
+---
+spec: issue-366-moratorium
+phase: design
+created: 2026-04-29
+---
+
+# Design: issue-366-moratorium
+
+## 1. Overview
+
+Single ESM script (~80 LOC) + 1 workflow job addition + ~10 lines added to CLAUDE.md + 4 spec artifacts. Mirror the `verify-z-classes.mjs` precedent: Node stdlib only, zero deps, binary exit code, multi-line failure message linking to root cause. Total file impact: 4-5 files; **zero post JSONs modified** (self-passes its own check).
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph CI["GitHub Actions: lockfile-check.yml"]
+        Trigger[pull_request to main] --> Job1[pnpm-frozen-lockfile]
+        Trigger --> Job2[build]
+        Trigger --> Job3[mass-edit-check NEW]
+        Job3 --> Checkout[checkout fetch-depth:0]
+        Checkout --> Script[node scripts/check-mass-edit.mjs]
+        Script --> Diff[git diff --name-only base...HEAD]
+        Diff --> Filter[regex: src/newblog/data/posts/*.json]
+        Filter --> Decision{count > 20?}
+        Decision -->|no| Pass[exit 0]
+        Decision -->|yes, has tag| Pass
+        Decision -->|yes, no tag| Fail[exit 1: stderr w/ link to #366]
+    end
+    PRBody[PR description ${{ github.event.pull_request.body }}] -.PR_BODY env.-> Script
+```
+
+## 2. Module Shape — `scripts/check-mass-edit.mjs`
+
+**Code skeleton** (final implementation will mirror this exactly):
+
+```js
+#!/usr/bin/env node
+/**
+ * check-mass-edit.mjs
+ *
+ * CI guardrail for the mass-edit moratorium (issue #366, expires 2026-07-15).
+ * Fails if a PR modifies > THRESHOLD post JSONs without [mass-edit-allowed]
+ * in the PR description.
+ *
+ * Mirrors scripts/verify-z-classes.mjs precedent: Node stdlib only, zero deps,
+ * binary exit code, multi-line failure message linking to root cause.
+ *
+ * Usage:
+ *   node scripts/check-mass-edit.mjs                                  # default base=origin/main, threshold=20
+ *   node scripts/check-mass-edit.mjs --base HEAD~5                    # local testing
+ *   node scripts/check-mass-edit.mjs --pr-body "..." --threshold 10   # CLI override
+ *
+ * Refs: https://github.com/kavanaghpatrick/dhm-guide-website/issues/366
+ *       CLAUDE.md "Mass-Edit Moratorium Policy" section
+ */
+
+import { execSync } from 'node:child_process';
+
+// Argv parsing (stdlib only)
+const args = process.argv.slice(2);
+const getFlag = (name, def) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? def : args[i + 1];
+};
+
+const BASE = getFlag('base', 'origin/main');
+const THRESHOLD = parseInt(getFlag('threshold', '20'), 10);
+const PR_BODY = getFlag('pr-body', process.env.PR_BODY || '');
+const OVERRIDE_TAG = '[mass-edit-allowed]';
+const POST_RE = /^src\/newblog\/data\/posts\/[^/]+\.json$/;
+
+// Determine modified post JSONs
+let changed;
+try {
+  changed = execSync(`git diff --name-only ${BASE}...HEAD`, { encoding: 'utf8' })
+    .split('\n')
+    .filter(f => POST_RE.test(f));
+} catch (e) {
+  console.error(`[check-mass-edit] Failed to compute diff against ${BASE}: ${e.message}`);
+  console.error('In CI, ensure actions/checkout uses fetch-depth: 0');
+  process.exit(2);
+}
+
+const count = changed.length;
+const hasOverride = PR_BODY.includes(OVERRIDE_TAG);
+
+if (count <= THRESHOLD) {
+  console.log(`[check-mass-edit] OK: ${count} post JSON(s) modified (threshold ${THRESHOLD})`);
+  process.exit(0);
+}
+
+if (hasOverride) {
+  console.log(`[check-mass-edit] OK (override): ${count} files modified, PR body contains ${OVERRIDE_TAG}`);
+  process.exit(0);
+}
+
+// Failure — clear, actionable error message
+console.error(`\n[check-mass-edit] FAIL — mass-edit moratorium violation`);
+console.error(`  Modified ${count} post JSONs in src/newblog/data/posts/ (threshold: ${THRESHOLD})`);
+console.error(`  This may trigger a Google recrawl wave during DCNI recovery`);
+console.error(`  (issue #366, expires 2026-07-15)`);
+console.error(``);
+console.error(`  Files (first 10):`);
+changed.slice(0, 10).forEach(f => console.error(`    ${f}`));
+if (count > 10) console.error(`    ... and ${count - 10} more`);
+console.error(``);
+console.error(`  To override (with rationale), add to PR description:`);
+console.error(`    ${OVERRIDE_TAG}`);
+console.error(``);
+console.error(`  Background: https://github.com/kavanaghpatrick/dhm-guide-website/issues/366`);
+console.error(`  Policy: CLAUDE.md "Mass-Edit Moratorium Policy" section\n`);
+process.exit(1);
+```
+
+**Design notes**:
+- ESM (`.mjs`) — matches `scripts/verify-z-classes.mjs`
+- Stdlib only: `node:child_process` for `execSync`. No npm deps.
+- Three flags (`--base`, `--threshold`, `--pr-body`) for local testing parity with CI.
+- Defensive: traps `execSync` error and emits the `fetch-depth: 0` hint.
+- Failure message order: WHAT → WHY → FILES → HOW TO OVERRIDE → BACKGROUND.
+
+## 3. Workflow Extension — `.github/workflows/lockfile-check.yml`
+
+**Add new job** AFTER existing `build` job. Same trigger (`pull_request: branches: [main]`), no `pnpm install` needed (Node stdlib only):
+
+```yaml
+  mass-edit-check:
+    name: Mass-edit moratorium check (#366, expires 2026-07-15)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check post JSON modification count
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-mass-edit.mjs --base origin/${{ github.base_ref }}
+```
+
+**Design notes**:
+- Job name embeds `expires 2026-07-15` — visible on every PR (forcing function for cleanup).
+- `fetch-depth: 0` — required for `git diff <base>...HEAD` to resolve.
+- `--base origin/${{ github.base_ref }}` — uses actual target branch (defensive; not hardcoded `main`).
+- `PR_BODY` passed via env (cleaner than shell-escaping a multi-line PR body into a flag); script falls back to env var when `--pr-body` flag absent.
+- No `pnpm install` step — script has zero deps.
+- `if: github.event_name == 'pull_request'` — defensive guard (workflow already filters, but explicit > implicit).
+
+## 4. CLAUDE.md Addition
+
+**Insertion point**: AFTER existing `## Spec Artifact Commit Policy` section (CLAUDE.md line 587, the `---` separator), BEFORE `## ⚠️ Red Flags (STOP and Simplify)` (line 591). Mirrors the spec-artifact section formatting precedent.
+
+**Content** (~10 lines):
+
+```markdown
+## Mass-Edit Moratorium Policy
+
+**Active until 2026-07-15** (issue #366).
+
+Per the DCNI investigation (#362): mass-edits across many post JSONs trigger Google recrawl waves which re-evaluate posts against the current quality bar. PR #243 (147 files) and #246 (197 files) caused measurable DCNI growth. The moratorium prevents recurrence during recovery.
+
+**The rule**: PRs modifying >20 files in `src/newblog/data/posts/` will FAIL CI.
+
+**Escape hatch**: Add `[mass-edit-allowed]` to PR description with rationale (e.g., "corpus restore from backup", "post-moratorium realignment").
+
+**At 2026-07-15**: remove this section, the workflow job, and `scripts/check-mass-edit.mjs`.
+
+**Tracking**: weekly DCNI count via GSC. See issue #366.
+```
+
+## File Structure
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `scripts/check-mass-edit.mjs` | Create | CI guardrail script (~80 LOC) |
+| `.github/workflows/lockfile-check.yml` | Modify | Add `mass-edit-check` job (~14 lines) |
+| `CLAUDE.md` | Modify | Insert "Mass-Edit Moratorium Policy" section (~13 lines) |
+| `specs/issue-366-moratorium/research.md` | Create | Spec artifact (already exists) |
+| `specs/issue-366-moratorium/requirements.md` | Create | Spec artifact (already exists) |
+| `specs/issue-366-moratorium/design.md` | Create | This file |
+| `specs/issue-366-moratorium/tasks.md` | Create | Generated next phase |
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant PR as PR opened/synced
+    participant GHA as GitHub Actions
+    participant Script as check-mass-edit.mjs
+    participant Git as git binary
+    PR->>GHA: pull_request event (branches: [main])
+    GHA->>GHA: checkout w/ fetch-depth:0, setup-node@22
+    GHA->>Script: node check-mass-edit.mjs --base origin/main<br/>env: PR_BODY=${{ github.event.pull_request.body }}
+    Script->>Git: git diff --name-only origin/main...HEAD
+    Git-->>Script: file list
+    Script->>Script: filter regex ^src/newblog/data/posts/[^/]+\.json$
+    alt count <= 20
+        Script-->>GHA: stdout OK, exit 0
+        GHA-->>PR: green check
+    else count > 20 AND PR_BODY contains [mass-edit-allowed]
+        Script-->>GHA: stdout OK (override), exit 0
+        GHA-->>PR: green check
+    else count > 20 AND no override
+        Script-->>GHA: stderr: count, files, override syntax, #366 link, exit 1
+        GHA-->>PR: red X (blocks merge once branch protection set)
+    end
+```
+
+## Technical Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|--------------------|--------|-----------|
+| Module format | `.mjs` ESM, `.cjs`, `.js` w/ `type: module` | `.mjs` | Matches `scripts/verify-z-classes.mjs` precedent (NFR-5) |
+| Dependencies | npm package (e.g., `simple-git`), stdlib | stdlib + `git` shellout | Pattern #1 simplicity; zero supply-chain risk |
+| Threshold | 10, 20, 30, 50 | 20 | Above largest non-triggering known PR (#84 = 13); below smallest wave-triggering (#243 = 147) |
+| Override mechanism | Label, file marker, PR body tag | PR body `[mass-edit-allowed]` | Mirrors `[skip ci]` idiom; greppable; signals intent in diff |
+| Workflow placement | New file, extend existing | Extend `lockfile-check.yml` | Per research recommendation; same trigger, simpler ops |
+| Diff command | `merge-base + diff`, `diff base...HEAD` (triple-dot) | `diff base...HEAD` | Triple-dot syntax does merge-base internally; one command vs two |
+| Job name format | Plain "Mass-edit check", with expiry date | "...(#366, expires 2026-07-15)" | Forcing function: cleanup deadline visible on every PR |
+| `--base` value in CI | Hardcode `origin/main`, dynamic | `origin/${{ github.base_ref }}` | Defensive against future PRs targeting other branches |
+| PR body delivery | CLI flag, env var | Env var (`PR_BODY`) with `--pr-body` fallback | Avoids shell-escaping multiline PR body; flag preserves local-test parity |
+| Renames | Special-case rename detection, count both | Count both | Acceptable false-positive; renames don't cause DCNI but err safe |
+| Auto-disable at expiry | Cron, date check in script, manual | Manual | Pattern #1 simplicity; expiry-in-job-name is the forcing function |
+
+## Error Handling
+
+| Error Scenario | Handling Strategy | User Impact |
+|----------------|-------------------|-------------|
+| `git diff` fails (shallow clone, missing ref) | `try/catch`; emit error w/ `fetch-depth: 0` hint; exit 2 | Contributor sees actionable hint in CI logs |
+| `parseInt(threshold)` returns `NaN` | Doc'd as caller error; not handled | Tester error, not user-facing |
+| PR_BODY null/undefined (e.g., draft PR with no description) | Default `''` via `process.env.PR_BODY || ''` | No override; threshold check runs normally |
+| Empty diff (zero changes) | Filtered list is empty; count = 0; exit 0 | Fast happy path with `OK: 0 post JSON(s) modified` |
+| Renamed posts | Both old and new path counted | Slight false-positive risk; documented edge case |
+| `--base` ref doesn't exist | `execSync` throws → exit 2 with hint | Local-dev only; CI guarantees `origin/main` |
+
+## Edge Cases
+
+- **PR retargeted from main → develop**: `--base origin/${{ github.base_ref }}` adapts automatically.
+- **Force-push that mass-deletes posts**: Deletions count toward threshold (intentional — also a sitemap signal change).
+- **Branch behind main**: Triple-dot `base...HEAD` resolves merge-base correctly; only divergent files counted.
+- **Empty PR body**: No override; threshold check applies. Conservative default.
+- **Branch protection not yet enabled (manual GitHub UI step)**: Job still runs, still reports red/green; merge isn't blocked until admin sets branch protection (AC-2.5, Medium priority).
+- **Self-test on this PR**: 0 post JSONs modified → exit 0 trivially.
+
+## Test Strategy
+
+### Manual Verification (per AC, Pattern #1 — no test framework)
+
+```bash
+# AC-1.1: script exists and is executable
+test -f scripts/check-mass-edit.mjs && echo "PASS"
+
+# AC-2.1: workflow has new job with expiry date
+grep -q "Mass-edit moratorium check (#366, expires 2026-07-15)" .github/workflows/lockfile-check.yml && echo "PASS"
+
+# AC-3.1: CLAUDE.md has new section
+grep -q "## Mass-Edit Moratorium Policy" CLAUDE.md && echo "PASS"
+
+# AC-4.2: self-test on this PR (zero post JSONs modified — should pass)
+node scripts/check-mass-edit.mjs --pr-body "" --base origin/main && echo "PASS self-test"
+
+# AC-4.3: threshold + override path (synthetic test)
+node scripts/check-mass-edit.mjs --pr-body "" --threshold 0 --base HEAD~1 ; echo "exit=$?"
+# Expected: exit 1 if any post JSON in last commit, exit 0 otherwise.
+node scripts/check-mass-edit.mjs --pr-body "[mass-edit-allowed]" --threshold 0 --base HEAD~1 ; echo "exit=$?"
+# Expected: exit 0 (override accepted)
+
+# AC-4.1: full build green
+npm run build && echo "PASS build"
+```
+
+No unit tests. Per Pattern #1 (simplicity) and research recommendation #6 ("simple shell-out, manual verification on the PR itself is the test").
+
+## Performance Considerations
+
+- Script wall time: <2s (one `git diff` + regex filter on small list).
+- CI job timeout: 2 minutes (NFR-6) — generous safety margin.
+- No `pnpm install` step in this job → faster than the `build` job (~30s vs minutes).
+
+## Security Considerations
+
+- **No secrets handled.** Script reads only `git diff` output and PR body string.
+- **PR body contains untrusted user input** but is only checked via `String.prototype.includes()` — no eval, no shell interpolation, no injection surface.
+- **`execSync` arg**: only the `--base` value is interpolated. In CI, `${{ github.base_ref }}` is a GitHub-controlled branch name (alphanumeric + `-`, `_`, `/`); not arbitrary user input. Local CLI use trusts the operator.
+- No npm deps → zero supply-chain attack surface added.
+
+## Existing Patterns to Follow
+
+Per research:
+- `scripts/verify-z-classes.mjs` (Pattern #15): Node stdlib only, multi-line `console.error` with cause + remedy + ref link, binary exit code.
+- `.github/workflows/lockfile-check.yml`: existing two-job workflow extended (not forked), `actions/checkout@v4` + `actions/setup-node@v4` standard, `pull_request: branches: [main]` trigger.
+- CLAUDE.md "Spec Artifact Commit Policy" (line 575): formatting precedent for adjacent "Mass-Edit Moratorium Policy" section.
+
+## 5. Verification Commands (Summary)
+
+| AC | Command | Expected |
+|----|---------|----------|
+| AC-1.1 | `test -f scripts/check-mass-edit.mjs && echo PASS` | PASS |
+| AC-2.1 | `grep -q "Mass-edit moratorium check" .github/workflows/lockfile-check.yml && echo PASS` | PASS |
+| AC-3.1 | `grep -q "## Mass-Edit Moratorium Policy" CLAUDE.md && echo PASS` | PASS |
+| AC-4.1 | `npm run build && echo PASS` | PASS (build green) |
+| AC-4.2 | `node scripts/check-mass-edit.mjs --pr-body "" --base origin/main && echo PASS` | PASS (zero post JSONs in this PR) |
+| AC-4.3 | `node scripts/check-mass-edit.mjs --pr-body "[mass-edit-allowed]" --threshold 0 --base HEAD~1 ; echo exit=$?` | exit=0 (override accepted) |
+
+**6 verification commands.** No external dependencies, all runnable locally + in CI.
+
+## 6. Risk Register
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Forgotten cleanup at 2026-07-15 | **Med (largest)** | Expiry date in workflow job name (visible on every PR) + CLAUDE.md "At 2026-07-15: remove..." instruction |
+| Local dev test breaks (no `origin/main` ref) | Low | Clear `try/catch` error message includes `fetch-depth: 0` hint and exit 2 |
+| Renamed posts counted as mass-edit | Low | Documented edge case; acceptable false-positive (renames don't trigger DCNI) |
+| `git diff` returns nothing in CI (shallow checkout) | High | `fetch-depth: 0` in workflow checkout (AC-2.3) |
+| Future contributor adds 21-file PR | Expected | Either splits PR or adds escape hatch — both acceptable per US-2 |
+| Bypass tag abused (every PR adds it) | Low | Tag is opt-in; rationale in PR body adjacent, reviewable in diff |
+| PR description not in CI context | Low | `${{ github.event.pull_request.body }}` is GitHub-native; works on first push to PR |
+
+## 7. PR Strategy — 4 Commits with `Co-Authored-By` Trailer
+
+Each commit ends with:
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+| # | Commit Message | Files Staged |
+|---|----------------|--------------|
+| 1 | `feat(scripts): add mass-edit moratorium CI guardrail script (#366)` | `scripts/check-mass-edit.mjs` only |
+| 2 | `ci: add mass-edit moratorium check job to lockfile workflow (#366)` | `.github/workflows/lockfile-check.yml` only |
+| 3 | `docs(claude): document mass-edit moratorium policy (#366)` | `CLAUDE.md` only |
+| 4 | `chore(spec): scaffold ralph spec artifacts for issue #366` | `specs/issue-366-moratorium/{research,requirements,design,tasks}.md` |
+
+**Sequence rationale**: script first (the artifact being referenced), workflow second (depends on script existing in tree), docs third (depends on script + workflow as referent), spec artifacts last (meta — describes the work itself). This order keeps each commit independently revertible without breaking earlier ones.
+
+## Unresolved Questions
+
+None blocking. All design choices defensible from existing precedent (`verify-z-classes.mjs`, `lockfile-check.yml`, CLAUDE.md spec-artifact section).
+
+## Implementation Steps
+
+1. Create `scripts/check-mass-edit.mjs` with the skeleton in §2 (verify exit codes via local synthetic tests).
+2. Verify locally: `node scripts/check-mass-edit.mjs --pr-body "" --base origin/main` exits 0 on this branch.
+3. Verify override: `node scripts/check-mass-edit.mjs --pr-body "[mass-edit-allowed]" --threshold 0 --base HEAD~3` exits 0.
+4. Edit `.github/workflows/lockfile-check.yml` — append `mass-edit-check` job per §3.
+5. Edit `CLAUDE.md` — insert "Mass-Edit Moratorium Policy" section per §4 between line 587 (`---`) and line 589 (`---` before Red Flags).
+6. Run `npm run build` — verify green.
+7. Stage and commit per the 4-commit plan in §7.
+8. Push branch; verify the CI job runs against itself and passes (self-test).
+9. After merge: manually enable branch protection requiring the `Mass-edit moratorium check` status (AC-2.5).

--- a/specs/issue-366-moratorium/requirements.md
+++ b/specs/issue-366-moratorium/requirements.md
@@ -1,0 +1,180 @@
+---
+spec: issue-366-moratorium
+phase: requirements
+created: 2026-04-29
+---
+
+# Requirements: issue-366-moratorium
+
+## Feature Description
+
+Build a CI guardrail that fails any PR modifying >20 post JSONs in `src/newblog/data/posts/`. Includes escape hatch via `[mass-edit-allowed]` PR description tag. Includes CLAUDE.md policy doc + workflow integration via extension of existing `.github/workflows/lockfile-check.yml`. Active until 2026-07-15 (expiry date embedded in CI job name as forcing function for manual cleanup).
+
+## Goal
+
+Prevent accidental mass-edit PRs from triggering further Google recrawl waves during DCNI recovery (per #366, child of #362). Structural prevention via CI > policy memory.
+
+## User Stories
+
+### US-1: Block accidental mass-edits
+**As a** future contributor (or future me)
+**I want** CI to block accidental mass-edits during the moratorium
+**So that** I don't trigger another DCNI wave like PR #243 (147 files) or #246 (197 files).
+
+**Acceptance Criteria:**
+- [ ] AC-1.1, AC-1.5–AC-1.9 (see Functional ACs below)
+- [ ] AC-2.1, AC-2.2, AC-2.4
+
+### US-2: Legitimate mass-edit escape hatch
+**As a** maintainer with a legitimate mass-edit need (corpus restore, post-moratorium realignment, FTC compliance fix)
+**I want** an explicit escape hatch via PR description tag
+**So that** I can opt-in deliberately without removing the guardrail.
+
+**Acceptance Criteria:**
+- [ ] AC-1.7: `[mass-edit-allowed]` in PR body bypasses threshold
+- [ ] AC-4.3: Override branch logic verified
+
+### US-3: Visible expiry date
+**As a** future contributor
+**I want** the moratorium expiry date visible in every PR's CI status
+**So that** I know when the moratorium lifts without hunting for it.
+
+**Acceptance Criteria:**
+- [ ] AC-2.1: Job name embeds `expires 2026-07-15`
+- [ ] AC-3.3: CLAUDE.md section documents expiry
+
+### US-4: Self-passing PR
+**As a** spec author
+**I want** this PR (which adds the guardrail) to pass its own check
+**So that** I don't have to invoke the escape hatch on the PR that ships the escape hatch.
+
+**Acceptance Criteria:**
+- [ ] AC-4.1, AC-4.2
+
+## Functional Requirements
+
+### FR-1: CI guardrail script (`scripts/check-mass-edit.mjs`)
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| AC-1.1 | New file `scripts/check-mass-edit.mjs` exists; ESM (`.mjs`); no new npm deps | High |
+| AC-1.2 | Supports `--pr-body <string>` flag for local testing without GitHub Actions context | High |
+| AC-1.3 | Supports `--threshold <N>` flag; default = 20 | High |
+| AC-1.4 | Supports `--base <ref>` flag; default = `origin/main` | High |
+| AC-1.5 | Reads modified-file list via `git diff --name-only <base>...HEAD` | High |
+| AC-1.6 | Counts files matching `src/newblog/data/posts/*.json` (precise regex `^src/newblog/data/posts/[^/]+\.json$`) | High |
+| AC-1.7 | Exits 0 if count ≤ threshold OR PR body contains `[mass-edit-allowed]` | High |
+| AC-1.8 | Exits 1 with clear stderr error message if count > threshold AND no override | High |
+| AC-1.9 | Error message includes: count, threshold, link to issue #366, escape-hatch syntax `[mass-edit-allowed]`, file list (truncated to first 10) | High |
+
+### FR-2: Workflow integration (`.github/workflows/lockfile-check.yml`)
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| AC-2.1 | Existing workflow extended (NOT forked) with new job named `Mass-edit moratorium check (#366, expires 2026-07-15)` | High |
+| AC-2.2 | New job runs on `pull_request: branches: [main]` (not pushes) | High |
+| AC-2.3 | Job uses `actions/checkout@v4` with `fetch-depth: 0` (required for `git merge-base`) | High |
+| AC-2.4 | Job runs `node scripts/check-mass-edit.mjs --pr-body "${{ github.event.pull_request.body }}"` | High |
+| AC-2.5 | Job is required for merge (manual GitHub branch-protection setting; document in PR description) | Medium |
+
+### FR-3: CLAUDE.md policy doc
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| AC-3.1 | New `## Mass-Edit Moratorium Policy` section added to CLAUDE.md | High |
+| AC-3.2 | Section placed adjacent to existing `## Spec Artifact Commit Policy` (post-#345 precedent), before `Red Flags` section | High |
+| AC-3.3 | Section includes: expiry date 2026-07-15, threshold 20, escape-hatch syntax `[mass-edit-allowed]`, link to #366 | High |
+
+### FR-4: Self-test + build
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| AC-4.1 | `npm run build` exits 0 | High |
+| AC-4.2 | `node scripts/check-mass-edit.mjs --pr-body "" --base origin/main` on this PR's branch exits 0 (zero post JSONs modified) | High |
+| AC-4.3 | Override path verified: with `--pr-body "[mass-edit-allowed]"` the script exits 0 even when count > threshold (test via shell harness or faked diff) | High |
+
+**Total: 18 ACs across 4 FRs.**
+
+## Non-Functional Requirements
+
+| ID | Requirement | Metric | Target |
+|----|-------------|--------|--------|
+| NFR-1 | Module format | ESM (`.mjs`) | Required by repo conventions |
+| NFR-2 | Dependencies | New npm packages | 0 (Node stdlib + git only) |
+| NFR-3 | Execution speed | Wall time | <2s |
+| NFR-4 | Error message clarity | Includes WHY, not just FAIL | Mandatory: count, threshold, #366 link, escape-hatch syntax, file list |
+| NFR-5 | Code style | Mirror precedent | Match `scripts/verify-z-classes.mjs` (per Pattern #15) |
+| NFR-6 | CI runtime | Job timeout | 2 minutes |
+
+## Glossary
+
+- **DCNI**: Discovered – Currently Not Indexed (Google Search Console status). Indicator of templated-batch-content penalty.
+- **Mass-edit PR**: Any PR modifying >20 post JSON files in `src/newblog/data/posts/`. Empirically correlates with sitemap recrawl waves.
+- **Moratorium**: Active prohibition window (2026-04-29 → 2026-07-15) during which mass-edits are blocked.
+- **Escape hatch**: `[mass-edit-allowed]` literal string in PR description that bypasses the check.
+- **Threshold**: 20 files. Conservative ceiling above largest non-triggering known PR (~13 files in #84) and well below smallest known wave-triggering PR (147 in #243).
+
+## Edge Cases
+
+| Case | Behavior | Rationale |
+|------|----------|-----------|
+| `origin/main` not fetched locally | Script fails with clear error if base ref doesn't resolve | Local-dev mitigation |
+| PR body is null/empty (e.g., GitHub Actions on PR with no description) | Treat as no override; check threshold normally | Conservative default |
+| 0 modified post JSONs (most PRs) | Pass quickly with `OK: 0 post JSONs modified.` | Fast happy path |
+| Renamed files in `src/newblog/data/posts/` | `git diff --name-only` shows old + new path; both counted | Acceptable false-positive risk; renames don't trigger DCNI waves the same way as content edits — documented |
+| Deleted post JSON files | Count toward threshold | Deletion is also a sitemap signal change |
+| Branch behind main | `git merge-base` resolves correctly; only divergent files counted | Standard `git diff` behavior |
+
+## Out of Scope
+
+- Automated GSC monitoring (requires API credentials; manual weekly check per #366 ACs)
+- Auto-disable at moratorium-end 2026-07-15 (manual cleanup; expiry date embedded in CI job name as forcing function)
+- "Warn" mode (binary pass/fail only; per Pattern #1)
+- Counting LOC changes inside files (file count alone is sufficient signal)
+- Tests for the script itself (Pattern #1: simple shell-out; PR self-test is the verification)
+- Branch-protection setting in GitHub UI (manual; documented in PR description)
+
+## Dependencies
+
+- Node 22 (already in CI via `actions/setup-node@v4`)
+- `git` binary (CI runner has it)
+- GitHub Actions context var `${{ github.event.pull_request.body }}` (native; no API call)
+- `actions/checkout@v4` with `fetch-depth: 0` (required for `git merge-base` resolution)
+
+## Constraints
+
+- Don't add npm dependencies
+- Don't fork a new workflow file (extend existing `.github/workflows/lockfile-check.yml`)
+- Don't auto-disable at expiry (manual cleanup at 2026-07-15)
+- Don't add warn mode (binary pass/fail)
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Future contributor doesn't understand the failure → frustration | Medium | AC-1.9 — error message includes count, threshold, #366 link, CLAUDE.md anchor, escape-hatch syntax, file list (truncated to 10) |
+| **Forgotten cleanup at 2026-07-15 → moratorium becomes permanent annoyance** | **Medium (biggest risk)** | Expiry date embedded in CI job name `Mass-edit moratorium check (#366, expires 2026-07-15)` — visible on every PR as forcing function |
+| Renames flagged as mass-edit | Low | Documented edge case; acceptable false-positive risk — counts old + new path |
+| GSC monitoring NOT automated | Low | Out-of-scope per #366; manual weekly check |
+| Bypass abuse (someone tags every PR with override) | Low | Override is opt-in; rationale lives in PR body adjacent to tag, reviewable in PR diff |
+| Shallow clone breaks `git merge-base` | Low | `fetch-depth: 0` in `actions/checkout@v4` step (AC-2.3) |
+
+## Success Criteria
+
+1. CI fails on a PR with >20 post JSONs modified and no `[mass-edit-allowed]` tag
+2. CI passes on the same PR after `[mass-edit-allowed]` is added to PR description
+3. CI passes on this PR (which ships the guardrail) without override (zero post JSONs modified)
+4. Future contributor reading the CI failure message understands: what was blocked, why, how to override
+5. Expiry date 2026-07-15 visible on every PR's CI status
+
+## Unresolved Questions
+
+None blocking. All design choices defensible from existing precedent (`verify-z-classes.mjs`, `lockfile-check.yml`, CLAUDE.md spec-artifact section).
+
+## Next Steps
+
+1. Generate `design.md` (technical design — script structure, workflow YAML, CLAUDE.md insertion point)
+2. Generate `tasks.md` (concrete implementation steps)
+3. Implement: `scripts/check-mass-edit.mjs` + workflow extension + CLAUDE.md section
+4. Verify self-test on this PR (CI job runs against itself, passes)
+5. Manual: enable branch protection on the new required check after merge

--- a/specs/issue-366-moratorium/research.md
+++ b/specs/issue-366-moratorium/research.md
@@ -1,0 +1,233 @@
+---
+spec: issue-366-moratorium
+phase: research
+created: 2026-04-29
+---
+
+# Research: issue-366-moratorium
+
+## Executive Summary
+
+Build a CI guardrail (`scripts/check-mass-edit.mjs` + new job in `.github/workflows/lockfile-check.yml`) that fails any PR modifying >20 JSON files in `src/newblog/data/posts/` unless the PR description contains `[mass-edit-allowed]`. Mirrors the `verify-z-classes.mjs` precedent: simple Node script, no deps, binary pass/fail, structural prevention. Self-test: this PR touches ~5 files, zero post JSONs — passes.
+
+## External Research
+
+### Best Practices
+
+| Source | Finding |
+|--------|---------|
+| GitHub Actions docs (`github.event.pull_request.body`) | PR description natively available in CI context — no API call needed |
+| `git merge-base origin/main HEAD` + `git diff --name-only` | Canonical way to enumerate PR-changed files; counts files, not bytes |
+| `actions/checkout@v4` with `fetch-depth: 0` | Required for merge-base to resolve in CI (default shallow clone breaks `git merge-base`) |
+| Conventional opt-in tags (e.g. `[skip ci]`, `[skip-changelog]`) | Bracketed tag in PR description / commit message is the standard escape-hatch idiom |
+
+### Prior Art (in this repo)
+
+- `scripts/verify-z-classes.mjs` — Node, zero deps, scans source vs build artifact, binary exit code, clear failure message linking to root-cause section in CLAUDE.md (Pattern #15). **Mirror this pattern.**
+- `.github/workflows/lockfile-check.yml` — two-job workflow (`pnpm-frozen-lockfile`, `build`), runs on `pull_request: branches: [main]`, uses `actions/checkout@v4` + `pnpm/action-setup@v4` + `actions/setup-node@v4`. **Add a third job here, don't fork a new workflow file.**
+
+### Pitfalls to Avoid
+
+- Shallow clone breaks `git merge-base` → must set `fetch-depth: 0` in checkout step.
+- `git diff --name-only HEAD~1` is wrong (only catches last commit; PR may have many). Must use `git merge-base origin/main HEAD` then diff against that.
+- Globs need precise filter: `^src/newblog/data/posts/[^/]+\.json$` to avoid catching nested fixtures or non-JSON files.
+- "Warn" mode looks friendly but creates ambiguity (was the warning seen?). Binary pass/fail is simpler — Pattern #1.
+
+## Codebase Analysis
+
+### Existing Patterns
+
+- **Build-time guard scripts**: `scripts/verify-z-classes.mjs` is the model. Plain `.mjs`, `process.cwd()` for paths, `process.exit(1)` on fail with multi-line `console.error` explaining cause + remedy.
+- **CI workflow shape**: `.github/workflows/lockfile-check.yml` runs on `pull_request: branches: [main]`, uses `actions/checkout@v4` + node 22. Add a peer job alongside `pnpm-frozen-lockfile` and `build`.
+- **Spec-artifact policy precedent**: CLAUDE.md line 575 has a "Spec Artifact Commit Policy" section. Add the new "Mass-Edit Moratorium Policy" section adjacent, before the "Red Flags" section at line 591.
+
+### Dependencies
+
+- Node 22 (already in CI). No npm packages needed — script uses only `node:child_process` (`execSync('git diff --name-only ...')`) and stdlib.
+- `git` (CI runner has it).
+- GitHub Actions context vars: `${{ github.event.pull_request.body }}` (PR description, available natively).
+
+### Constraints
+
+- 202 post JSON files in `src/newblog/data/posts/` (verified). Threshold of 20 = ~10% of corpus.
+- Workflow only needs to run on `pull_request` events to `main` (matches existing pattern). No need on push to main (post-merge is too late).
+- Script must work both in CI (read PR body from env) AND locally (read from `--pr-body` flag).
+
+## The 20-File Threshold Rationale
+
+| PR | Files modified | Triggered recrawl wave? |
+|----|---------------|-------------------------|
+| #243 (Feb 1, 2026) | 147 (relatedPosts regen) | YES — drove DCNI 0→120 over Jan 29–Apr 16 |
+| #246 (Apr 29, 2026) | 197 (hub-footer auto-injection) | EXPECTED YES — wave projected May 5 onward |
+| #84 (metadata cleanup) | ~13 | NO |
+| #86 (broken-link fix) | ~8 | NO |
+
+**Choice of 20**: conservative ceiling above the largest non-triggering known PR (~13 files in #84) and well below the smallest known wave-triggering PR (147 in #243). 20 files = ~10% of the 202-post corpus, safely below the threshold where Google starts treating sitemap timestamp churn as a templated batch-content signal. Round number, easy to remember, easy to defend.
+
+## CI Guardrail Design
+
+**Script**: `scripts/check-mass-edit.mjs`
+
+```
+1. Parse args: --pr-body=<string> (default: process.env.PR_BODY || '')
+2. Compute merge base: execSync('git merge-base origin/main HEAD').trim()
+3. Diff: execSync(`git diff --name-only ${base}..HEAD`).split('\n')
+4. Filter: lines matching /^src\/newblog\/data\/posts\/[^/]+\.json$/
+5. Count = filtered.length
+6. If count > 20 AND NOT prBody.includes('[mass-edit-allowed]'):
+     console.error with link to #366 + CLAUDE.md section + escape-hatch syntax
+     process.exit(1)
+   Else:
+     console.log(`OK: ${count} post JSONs modified (<= 20 OR override present).`)
+     process.exit(0)
+```
+
+**Edge cases**:
+- New post additions (not modifications): still counted by `git diff --name-only` — intentional. Adding 30 new posts is also a sitemap timestamp event.
+- Renames: `git diff --name-only` shows both old + new paths. Acceptable — counts as 2.
+- Branch behind main: merge-base resolves correctly; we count only files diverged on this branch.
+
+## GitHub Actions Integration
+
+**Recommendation**: Add a new job `mass-edit-moratorium` to existing `.github/workflows/lockfile-check.yml`. Same trigger (`pull_request: branches: [main]`), same `actions/checkout@v4` + `actions/setup-node@v4` pattern.
+
+```yaml
+mass-edit-moratorium:
+  name: Mass-edit moratorium check (#366, expires 2026-07-15)
+  runs-on: ubuntu-latest
+  timeout-minutes: 2
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # required for git merge-base
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: Check mass-edit threshold
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: node scripts/check-mass-edit.mjs
+```
+
+No `pnpm install` needed — script uses only Node stdlib + git.
+
+## Escape-Hatch Design
+
+**Trigger**: PR description contains literal `[mass-edit-allowed]`.
+
+**Why bracketed**: matches `[skip ci]` convention. Easy to grep, hard to type accidentally.
+
+**Why intentional friction**: the bypass requires a deliberate edit to the PR body, signaling "I considered the moratorium and have a reason." The reason should be in the PR body adjacent to the tag.
+
+**Legitimate uses**:
+- Restoring corpus from backup (e.g., post-incident recovery)
+- Cluster realignment after the moratorium expires (post-2026-07-15)
+- Emergency content compliance fix (FTC, FDA, broken affiliate disclosures)
+- Discovery of widespread broken JSON-LD or canonical regression
+
+## CLAUDE.md Addition
+
+Add immediately before line 589 (the `---` separator preceding "Red Flags"):
+
+```markdown
+## Mass-Edit Moratorium Policy
+
+**Active until 2026-07-15** (per #366, child of #362 DCNI investigation).
+
+PRs modifying >20 files in `src/newblog/data/posts/` will FAIL CI. This prevents Google recrawl waves during DCNI recovery.
+
+**Override**: Add `[mass-edit-allowed]` to PR description with rationale.
+
+**Tracking**: weekly DCNI count via GSC. Lift moratorium when DCNI stabilizes below 102 (pre-wave baseline).
+
+**Why 20**: PR #243 (147 files) and #246 (197 files) triggered measurable recrawl waves; #84 (~13 files) and #86 (~8 files) did not. 20 = conservative ceiling.
+```
+
+## Self-Test
+
+This PR ships:
+1. `scripts/check-mass-edit.mjs` (new file, ~50 LOC)
+2. `.github/workflows/lockfile-check.yml` (edit, +20 LOC for new job)
+3. `CLAUDE.md` (edit, +10 LOC for new section)
+4. `specs/issue-366-moratorium/research.md` (this file)
+5. `specs/issue-366-moratorium/requirements.md` + `design.md` + `tasks.md` (forthcoming)
+
+= ~5 files, **zero** post JSONs. The check runs against itself and passes.
+
+## Risk Register
+
+| Risk | Mitigation |
+|------|------------|
+| False positive — legitimate small PR flagged | Precise regex filter `^src/newblog/data/posts/[^/]+\.json$` only counts changed files (not size); diff via `git diff --name-only` |
+| Contributor confused by failure | Failure message includes: link to #366, link to CLAUDE.md section, exact escape-hatch syntax `[mass-edit-allowed]`, list of offending file paths |
+| PR description not in CI context | GitHub Actions provides `${{ github.event.pull_request.body }}` natively as env var |
+| Local testing without CI | Script reads `--pr-body=<string>` flag for offline testing |
+| Shallow clone breaks merge-base | `fetch-depth: 0` in `actions/checkout@v4` step |
+| Forgotten removal at 2026-07-15 | Workflow job name embeds expiry date: `Mass-edit moratorium check (#366, expires 2026-07-15)` — visible on every PR |
+| Bypass abuse | Tag is opt-in; rationale lives in PR body adjacent to tag, reviewable in PR diff |
+
+## Quality Commands
+
+| Type | Command | Source |
+|------|---------|--------|
+| Lint | Not found (no lint script) | package.json scripts |
+| TypeCheck | Not found | package.json scripts |
+| Test | Not found | package.json scripts |
+| Build | `pnpm run build` | package.json (existing CI uses this) |
+
+**Local CI for this spec**: `node scripts/check-mass-edit.mjs --pr-body=""` from repo root with `origin/main` fetched.
+
+## Verification Tooling
+
+Not applicable — this spec ships build-time guards, no runtime/E2E.
+
+| Aspect | Detail |
+|--------|--------|
+| Project type | Static site (Vite + React, prerendered) |
+| Verification strategy | Run script locally with empty PR body → expect exit 0 (PR has 0 post JSONs); manually craft a fake diff list → expect exit 1; in CI, the `lockfile-check` workflow run on this PR is the live verification |
+
+## Verification Approach (per AC)
+
+| AC | Test |
+|----|------|
+| Script exists and runs | `node scripts/check-mass-edit.mjs --pr-body="" && echo OK` |
+| Workflow has new job | `grep -q "mass-edit-moratorium" .github/workflows/lockfile-check.yml` |
+| CLAUDE.md has new section | `grep -q "Mass-Edit Moratorium Policy" CLAUDE.md` |
+| Self-test passes on this PR | CI run on the PR for this spec → green check on `mass-edit-moratorium` job |
+| Override works | Manually test: `node scripts/check-mass-edit.mjs --pr-body="[mass-edit-allowed]"` against a faked 30-file diff → exit 0 |
+| Failure mode is clear | Run against faked 30-file diff with empty PR body → stderr contains #366 link, CLAUDE.md anchor, escape-hatch syntax |
+
+## Out of Scope
+
+- Automated GSC monitoring (requires API credentials; manual weekly check per #366 ACs)
+- Auto-disable at 2026-07-15 (manual; user removes guardrail when window closes — see Risk Register: job name embeds expiry date as forcing function)
+- "Warn" mode (binary pass/fail is simpler; Pattern #1)
+- Counting LOC changes inside files (file count alone is sufficient signal — sitemap `lastmod` bumps regardless of edit size)
+
+## Related Specs
+
+Scanned `specs/` for related work. No directly conflicting specs found. Adjacent specs reference #362 lineage:
+- This spec (#366) is sibling to: #363 (Action 1 technical bugs), #364 (Action 2 hub promotion), #365 (Action 3 Save/Merge/Delete — DEFERRED until post-moratorium per #366).
+- The script intentionally does NOT block #363 or #364 since those touch ≤4 files each.
+
+## Recommendations for Requirements
+
+1. Single script `scripts/check-mass-edit.mjs`, ~50 LOC, Node stdlib only, zero deps.
+2. Single job add to `.github/workflows/lockfile-check.yml` — extend, don't fork.
+3. Job name MUST include "expires 2026-07-15" so the deletion date is visible on every PR.
+4. Failure message MUST include: file count, file list (truncated to first 5), link to #366, link to CLAUDE.md anchor, escape-hatch syntax.
+5. CLAUDE.md addition placed immediately before "Red Flags" section, mirroring "Spec Artifact Commit Policy" format.
+6. No tests for the script (Pattern #1: simple shell-out, manual verification on the PR itself is the test).
+
+## Open Questions
+
+None blocking. All design choices are defensible from existing precedent (verify-z-classes.mjs, lockfile-check.yml, CLAUDE.md spec-artifact section).
+
+## Sources
+
+- GitHub issue #366: `gh issue view 366` (full text reviewed)
+- `.github/workflows/lockfile-check.yml` (existing CI workflow pattern)
+- `scripts/verify-z-classes.mjs` (build-time guard precedent)
+- `CLAUDE.md` lines 575–588 (Spec Artifact Commit Policy precedent)
+- `src/newblog/data/posts/` (verified 202 JSON files exist)
+- `.progress.md` for issue-366-moratorium (Original Goal + scope confirmation)

--- a/specs/issue-366-moratorium/tasks.md
+++ b/specs/issue-366-moratorium/tasks.md
@@ -1,0 +1,177 @@
+---
+spec: issue-366-moratorium
+phase: tasks
+created: 2026-04-29
+---
+
+# Tasks: issue-366-moratorium
+
+## Phase 1: CI Guardrail Script
+
+- [x] 1.1 Create `scripts/check-mass-edit.mjs`
+  - **Do**:
+    1. Create new file `scripts/check-mass-edit.mjs` per design.md §2 skeleton
+    2. Header docblock matching design (refs #366, expiry 2026-07-15, mirrors `verify-z-classes.mjs`)
+    3. ESM import `execSync` from `node:child_process`
+    4. Argv parsing (`--base`, `--threshold`, `--pr-body`); defaults: `origin/main`, 20, `process.env.PR_BODY || ''`
+    5. Compute changed files via `git diff --name-only ${BASE}...HEAD`; filter via `/^src\/newblog\/data\/posts\/[^/]+\.json$/`
+    6. Decision logic: count ≤ threshold → exit 0; override tag present → exit 0; else exit 1 with multi-line stderr (count, files first 10, override syntax, #366 link, CLAUDE.md ref)
+    7. `try/catch` around `execSync` → exit 2 with `fetch-depth: 0` hint
+  - **Files**: `scripts/check-mass-edit.mjs`
+  - **Done when**: File exists, ESM, no npm deps, exit 0 with `--pr-body "" --base origin/main` on this branch
+  - **Verify**: `test -f scripts/check-mass-edit.mjs && node scripts/check-mass-edit.mjs --pr-body "" --base origin/main && echo PASS`
+  - **Commit**: None (batched in 1.4)
+  - _Requirements: AC-1.1, AC-1.2, AC-1.3, AC-1.4, AC-1.5, AC-1.6, AC-1.7, AC-1.8, AC-1.9_
+  - _Design: §2_
+
+- [x] 1.2 [VERIFY] Self-test: zero post JSONs in this branch passes
+  - **Do**:
+    1. Ensure `origin/main` is fetched: `git fetch origin main`
+    2. Run script with empty PR body against this branch
+  - **Files**: none
+  - **Done when**: Script exits 0 with `OK: 0 post JSON(s) modified`
+  - **Verify**: `node scripts/check-mass-edit.mjs --pr-body "" --base origin/main && echo VE_SELFTEST_PASS`
+  - **Commit**: None
+  - _Requirements: AC-4.2_
+
+- [x] 1.3 [VERIFY] Override path: tag bypasses threshold even when count exceeds
+  - **Do**:
+    1. Pick a base ref that includes >0 post JSON modifications (use `HEAD~50` or any historical ref where post JSONs were edited)
+    2. Run script with `--threshold 0 --pr-body "[mass-edit-allowed]"` against that base — must exit 0
+    3. Run same with `--threshold 0 --pr-body ""` — must exit 1 (proves the threshold check actually fires when override absent)
+  - **Files**: none
+  - **Done when**: Override exits 0, no-override exits 1
+  - **Verify**: `node scripts/check-mass-edit.mjs --threshold 0 --pr-body "[mass-edit-allowed]" --base HEAD~50 && echo VE_OVERRIDE_PASS && (node scripts/check-mass-edit.mjs --threshold 0 --pr-body "" --base HEAD~50 ; test $? -eq 1 && echo VE_NO_OVERRIDE_PASS)`
+  - **Commit**: None
+  - _Requirements: AC-4.3, AC-1.7, AC-1.8_
+
+- [x] 1.4 [COMMIT] Stage and commit script
+  - **Do**:
+    1. `git add scripts/check-mass-edit.mjs`
+    2. `git status --short` — verify ONLY `scripts/check-mass-edit.mjs` staged
+    3. Commit with HEREDOC message per design §7 commit #1
+  - **Files**: staged: `scripts/check-mass-edit.mjs`
+  - **Done when**: Commit exists; `git log -1 --name-only` shows only the script
+  - **Verify**: `git log -1 --pretty=format:%s | grep -q "feat(scripts): add mass-edit moratorium CI guardrail script (#366)" && git log -1 --name-only --pretty=format: | tr -d '\n ' | grep -qx "scripts/check-mass-edit.mjs" && echo COMMIT1_PASS`
+  - **Commit**: `feat(scripts): add mass-edit moratorium CI guardrail script (#366)` (with `Co-Authored-By` trailer)
+
+## Phase 2: Workflow Extension
+
+- [x] 2.1 Add `mass-edit-check` job to `.github/workflows/lockfile-check.yml`
+  - **Do**:
+    1. Open `.github/workflows/lockfile-check.yml`
+    2. Append new job `mass-edit-check` after existing `build` job per design §3
+    3. Job name: `Mass-edit moratorium check (#366, expires 2026-07-15)`
+    4. `runs-on: ubuntu-latest`, `timeout-minutes: 2`, `if: github.event_name == 'pull_request'`
+    5. Steps: `actions/checkout@v4` with `fetch-depth: 0`, `actions/setup-node@v4` with `node-version: 22`, run step with `PR_BODY` env from `${{ github.event.pull_request.body }}` and command `node scripts/check-mass-edit.mjs --base origin/${{ github.base_ref }}`
+  - **Files**: `.github/workflows/lockfile-check.yml`
+  - **Done when**: New job exists; YAML well-formed
+  - **Verify**: `grep -q "Mass-edit moratorium check (#366, expires 2026-07-15)" .github/workflows/lockfile-check.yml && grep -q "mass-edit-check:" .github/workflows/lockfile-check.yml && grep -q "fetch-depth: 0" .github/workflows/lockfile-check.yml && echo PASS`
+  - **Commit**: None (batched in 2.3)
+  - _Requirements: AC-2.1, AC-2.2, AC-2.3, AC-2.4_
+  - _Design: §3_
+
+- [x] 2.2 [VERIFY] YAML structural sanity
+  - **Do**:
+    1. Confirm new job name string present (job-name AC)
+    2. Confirm `fetch-depth: 0` present (CI checkout AC)
+    3. Confirm `PR_BODY: ${{ github.event.pull_request.body }}` env line present
+    4. Confirm `--base origin/${{ github.base_ref }}` argument present
+  - **Files**: none
+  - **Done when**: All 4 grep assertions pass
+  - **Verify**: `grep -q "Mass-edit moratorium check (#366, expires 2026-07-15)" .github/workflows/lockfile-check.yml && grep -q "fetch-depth: 0" .github/workflows/lockfile-check.yml && grep -q "PR_BODY:" .github/workflows/lockfile-check.yml && grep -q -- "--base origin/" .github/workflows/lockfile-check.yml && echo YAML_PASS`
+  - **Commit**: None
+
+- [x] 2.3 [COMMIT] Stage and commit workflow change
+  - **Do**:
+    1. `git add .github/workflows/lockfile-check.yml`
+    2. `git status --short` — verify ONLY workflow file staged
+    3. Commit with HEREDOC message per design §7 commit #2
+  - **Files**: staged: `.github/workflows/lockfile-check.yml`
+  - **Done when**: Commit exists; `git log -1 --name-only` shows only the workflow
+  - **Verify**: `git log -1 --pretty=format:%s | grep -q "ci: add mass-edit moratorium check job to lockfile workflow (#366)" && git log -1 --name-only --pretty=format: | tr -d '\n ' | grep -qx ".github/workflows/lockfile-check.yml" && echo COMMIT2_PASS`
+  - **Commit**: `ci: add mass-edit moratorium check job to lockfile workflow (#366)` (with `Co-Authored-By` trailer)
+
+## Phase 3: CLAUDE.md Policy Section
+
+- [x] 3.1 Insert "Mass-Edit Moratorium Policy" section
+  - **Do**:
+    1. Open `CLAUDE.md`
+    2. Insert new `## Mass-Edit Moratorium Policy` section AFTER the existing `## Spec Artifact Commit Policy` section (added by #345) and BEFORE `## ⚠️ Red Flags (STOP and Simplify)`
+    3. Section content per design §4: 4 required parts — (a) the rule (>20 files in `src/newblog/data/posts/` fails CI), (b) escape hatch syntax `[mass-edit-allowed]`, (c) expiry date 2026-07-15, (d) GSC tracking note
+  - **Files**: `CLAUDE.md`
+  - **Done when**: Section exists in correct position with all 4 parts
+  - **Verify**: `grep -q "## Mass-Edit Moratorium Policy" CLAUDE.md && echo PASS`
+  - **Commit**: None (batched in 3.3)
+  - _Requirements: AC-3.1, AC-3.2, AC-3.3_
+  - _Design: §4_
+
+- [x] 3.2 [VERIFY] All 4 required content elements present in section
+  - **Do**:
+    1. Section heading present
+    2. Expiry date `2026-07-15` mentioned
+    3. Threshold `20` and path `src/newblog/data/posts` mentioned
+    4. Escape hatch `[mass-edit-allowed]` mentioned
+    5. GSC tracking / DCNI tracking note present
+  - **Files**: none
+  - **Done when**: All 5 grep assertions pass
+  - **Verify**: `grep -q "## Mass-Edit Moratorium Policy" CLAUDE.md && grep -q "2026-07-15" CLAUDE.md && grep -q "src/newblog/data/posts" CLAUDE.md && grep -q "\[mass-edit-allowed\]" CLAUDE.md && (grep -q "GSC" CLAUDE.md || grep -q "DCNI" CLAUDE.md) && echo CLAUDE_MD_PASS`
+  - **Commit**: None
+
+- [x] 3.3 [COMMIT] Stage and commit CLAUDE.md
+  - **Do**:
+    1. `git add CLAUDE.md`
+    2. `git status --short` — verify ONLY `CLAUDE.md` staged
+    3. Commit with HEREDOC message per design §7 commit #3
+  - **Files**: staged: `CLAUDE.md`
+  - **Done when**: Commit exists; `git log -1 --name-only` shows only `CLAUDE.md`
+  - **Verify**: `git log -1 --pretty=format:%s | grep -q "docs(claude): document mass-edit moratorium policy (#366)" && git log -1 --name-only --pretty=format: | tr -d '\n ' | grep -qx "CLAUDE.md" && echo COMMIT3_PASS`
+  - **Commit**: `docs(claude): document mass-edit moratorium policy (#366)` (with `Co-Authored-By` trailer)
+
+## Phase 4: Integration Verification
+
+- [x] 4.1 [VERIFY] Build green
+  - **Do**: Run full project build to confirm no regression
+  - **Files**: none
+  - **Done when**: `npm run build` exits 0
+  - **Verify**: `npm run build && echo BUILD_PASS`
+  - **Commit**: None
+  - _Requirements: AC-4.1_
+
+- [x] 4.2 [VERIFY] Final self-test against current branch
+  - **Do**: Re-run script one more time against the now-committed state to confirm zero post JSONs and exit 0 (proves PR self-passes)
+  - **Files**: none
+  - **Done when**: Exit 0 with count = 0
+  - **Verify**: `node scripts/check-mass-edit.mjs --pr-body "" --base origin/main 2>&1 | grep -q "OK: 0" && echo FINAL_SELFTEST_PASS`
+  - **Commit**: None
+  - _Requirements: AC-4.2_
+
+## Phase 5: Spec Scaffold Commit
+
+- [x] 5.1 [COMMIT] Stage and commit spec artifacts
+  - **Do**:
+    1. Stage all 4 spec markdown files explicitly: `git add specs/issue-366-moratorium/research.md specs/issue-366-moratorium/requirements.md specs/issue-366-moratorium/design.md specs/issue-366-moratorium/tasks.md`
+    2. `git status --short` — verify ONLY the 4 spec files staged (no .progress.md, no .ralph-state.json — those are gitignored or not tracked)
+    3. Commit with HEREDOC message per design §7 commit #4
+  - **Files**: staged: `specs/issue-366-moratorium/{research,requirements,design,tasks}.md`
+  - **Done when**: Commit exists with exactly 4 files
+  - **Verify**: `git log -1 --pretty=format:%s | grep -q "chore(spec): scaffold ralph spec artifacts for issue #366" && [ "$(git log -1 --name-only --pretty=format: | grep -c "^specs/issue-366-moratorium/.*\.md$")" -eq 4 ] && echo COMMIT4_PASS`
+  - **Commit**: `chore(spec): scaffold ralph spec artifacts for issue #366` (with `Co-Authored-By` trailer)
+
+## Notes
+
+- **No `git add -A`** — every commit stages explicit paths.
+- **No PR creation / push tasks** — out of scope per quick-mode prompt.
+- **Self-passes own check** — this PR has zero post JSON modifications across all 4 commits combined; phase 4.2 proves it.
+- **Commit independence** — design §7 ordering (script → workflow → docs → spec) keeps each commit individually revertible.
+- **Forcing function** — workflow job name embeds `expires 2026-07-15` so the manual-cleanup deadline is visible on every PR run.
+- All commits include `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+
+## Commit Plan (Summary)
+
+| # | Phase | Subject | Staged Files |
+|---|-------|---------|--------------|
+| 1 | 1.4 | `feat(scripts): add mass-edit moratorium CI guardrail script (#366)` | `scripts/check-mass-edit.mjs` |
+| 2 | 2.3 | `ci: add mass-edit moratorium check job to lockfile workflow (#366)` | `.github/workflows/lockfile-check.yml` |
+| 3 | 3.3 | `docs(claude): document mass-edit moratorium policy (#366)` | `CLAUDE.md` |
+| 4 | 5.1 | `chore(spec): scaffold ralph spec artifacts for issue #366` | 4 spec markdown files |


### PR DESCRIPTION
Closes #366. Refs #362.

Adds CI guardrail to enforce the mass-edit moratorium during DCNI recovery (active until 2026-07-15).

**Why**: Per #362 investigation, PR #243 (147 files) and #246 (197 files) triggered Google recrawl waves causing DCNI growth. This CI check prevents accidental recurrence.

**The rule**: PRs modifying >20 files in `src/newblog/data/posts/` will FAIL CI.

**Escape hatch**: Add `[mass-edit-allowed]` to PR description with rationale.

**Forcing function for cleanup**: workflow job name embeds expiry date `(#366, expires 2026-07-15)` — visible on every PR check, prompts removal at moratorium end.

**Files**:
- `scripts/check-mass-edit.mjs` (76 LOC, ESM, no deps)
- `.github/workflows/lockfile-check.yml` (new job added)
- `CLAUDE.md` (new "Mass-Edit Moratorium Policy" section)
- 4 spec markdown files

**Verification**:
- Self-test passed (this PR has 0 post JSONs modified — passes its own check)
- Override branch verified against synthetic 198-file diff with `[mass-edit-allowed]` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)