### PR TITLE
test(visual): ground-truth capture + automated layout-invariant CI gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,7 @@ docs/modern-audit-2026-06-25/screenshots/
 
 # Site-consistency audit screenshots (regenerable: node scripts/capture-rest-of-site.mjs)
 docs/site-consistency-audit-2026-07-08/screenshots/
+
+# Visual-inspection ground-truth captures + audit evidence (regenerable: node scripts/visual-truth.mjs)
+docs/compare-visual-fix-2026-07-08/
+docs/visual-inspection-process-2026-07-08/ground-truth/

--- a/docs/visual-inspection-process-2026-07-08/PROCESS.md
+++ b/docs/visual-inspection-process-2026-07-08/PROCESS.md
@@ -1,0 +1,250 @@
+# Visual Inspection Process — Ground-Truth Capture + Automated Layout Invariants
+
+**Status:** Active · **Created:** 2026-07-08 · **Owner:** test-infra
+
+This replaces the old "capture thumbnails, eyeball them" visual-QA process that
+let a broken `/compare` comparison table reach 100% of users. It has two parts:
+
+1. **`scripts/visual-truth.mjs`** — artifact-free, ground-truth screenshot capture
+   (for human review + a machine-readable invariant report).
+2. **`tests/layout-invariants.spec.js`** — a Playwright gate that FAILS a build on
+   measurable layout defects (the thing the old process could never do).
+
+---
+
+## Why the old process failed (the failure taxonomy)
+
+The `/compare` "Detailed comparison" table shipped broken because **the entire
+visual pipeline was artifact-prone capture + human eyeballing, with zero automated
+layout invariant that could turn CI red.** Concretely:
+
+### F0 — No visual assertion can fail the build
+- `test:e2e` runs in CI, but the visual specs are `testIgnore`d from it
+  (`playwright.config.js` → `testIgnore: ['**/visual/**', ...]`).
+- The dedicated `visual` CI job is `continue-on-error: true` and runs
+  `test:visual:update` — which only **generates** baselines with
+  `--update-snapshots`. It never **compares** against them.
+- Net: there is no configuration under which a visual regression, an overflowing
+  table, a header overlap, or a layout shift can make CI red. The visual suite is
+  a baseline *generator*, not a *gate*.
+
+### F1 — Fixed ~1500px scroll bands miss mid-scroll states
+`scripts/capture-modern-audit.mjs` captures at `y = i * 1500` → frames land at
+0/1500/3000/4500. Any defect whose failure window is *between* those altitudes is
+never sampled. Continuous scrolling by a real user is not modeled.
+
+### F2 — fullPage / element-crop capture MANUFACTURES defects that don't exist
+This is the subtle one, and it caused false "findings":
+- **fullPage** composites the whole document into one image. A `position: fixed`
+  header paints once at the top, leaving a large empty region below where it would
+  have re-painted → the fake **"empty green band."** No real user sees it.
+- **element (`.screenshot`) crops** re-render a node outside its scroll/stacking
+  context, so a fixed nav can appear to **overlap** content it never overlaps in
+  the real viewport → the fake **"header overlaps the table."**
+- Both artifacts were initially attributed to `/compare` as real bugs. Ground-truth
+  viewport capture proves the shipped page does **not** exhibit them at rest (the
+  header is opaque; the green regions are intentional narrow-content sections).
+
+### F3 — Downscaled thumbnails hide fine defects
+1px misalignment, clipped text, and sub-pixel overlap vanish when a 1440px frame
+is shrunk to a thumbnail. The reviewer literally cannot see them.
+
+### F4 — The one relevant automated check is STRUCTURALLY BLIND to this bug
+`compare-modern-behavior.spec.js` asserts "no horizontal overflow" via
+`documentElement.scrollWidth <= clientWidth`. But the table lives inside
+`.compare-scroll { overflow-x: auto }` (`theme-modern.css:817`), so the overflow is
+absorbed **inside the scroll box** — `documentElement.scrollWidth` never grows. The
+check passes while the table still requires sideways scrolling to read. The defect
+is invisible to the exact assertion that looks like it should catch it.
+
+### F5 — The laptop band (1024–1366) is never captured
+The table is `hidden lg:block` (renders at ≥1024px) with `th { minWidth: 200px }`.
+At the max 4 selected products it is ~1180px wide. In the 1024–1366 band it is
+widest relative to the viewport — and the old tool captured only 390px and 1440px,
+never the band where it breaks.
+
+---
+
+## The real `/compare` defect (verified on production)
+
+At **`/compare?products=1,2,3,4` @ 1024px**, the comparison table's scroll box has
+`scrollWidth = 1180px` inside `clientWidth = 974px` → the user must **swipe
+sideways** to read all four product columns. `products=1,2,3,4` is a first-class,
+documented feature ("Choose up to 4 supplements"). `documentElement` overflow is
+`0` — so the existing "no horizontal overflow" check (F4) is blind to it.
+
+`tests/layout-invariants.spec.js` catches exactly this, as invariant **(d)**:
+
+```
+[d: table-fit] A data <table> is not fully readable on /compare?products=1,2,3,4 @ 1024px:
+requires HORIZONTAL SCROLLING (scroll box content 1180px > visible 974px — the user must
+swipe sideways to read all columns). The page-level overflow check (a) is BLIND to this
+because the overflow is absorbed inside the overflow-x:auto box.
+```
+
+Full prod matrix (8 routes × 4 widths + the 4-product compare state): **35 passed,
+1 failed** — the single failure is this real defect. No false positives. The same
+test goes RED against **local dev** too, so wired into CI it blocks the defect
+*before* deploy.
+
+---
+
+## Part 1 — Ground-truth capture: `scripts/visual-truth.mjs`
+
+Replaces fixed-band/fullPage/element-crop capture with **what a real user's
+viewport shows**:
+
+- **Viewport-sized frames only** — `page.screenshot()` with **NO `fullPage`, NO
+  element clip**. This is the single most important rule (kills F2).
+- **Real scroll offsets**, stepping ~85% of viewport height (overlapping steps so
+  nothing falls between frames — kills F1).
+- **Real device widths**: `390, 768, 1024, 1366, 1440` — includes the laptop band
+  (kills F5).
+- **`deviceScaleFactor: 2`** (retina) — no downscaling that hides fine defects
+  (kills F3).
+- Waits for `document.fonts.ready`, the `.theme-modern` root, and a settle delay.
+- Emits **`report.json`**: per route×width invariant measurements (overflow,
+  header-overlap offenders, blank-band px, table fit, scrollHeight growth) so a
+  human scanning frames and the machine gate look at the same measured facts.
+
+### Usage
+
+```bash
+# Production (default www.dhmguide.com), all routes × widths:
+node scripts/visual-truth.mjs
+
+# Local dev:
+BASE_URL=http://localhost:5173 node scripts/visual-truth.mjs
+
+# A subset:
+node scripts/visual-truth.mjs --routes /compare,/reviews --widths 1024,1440
+node scripts/visual-truth.mjs --out /tmp/shots
+```
+
+Output: `docs/visual-inspection-process-2026-07-08/ground-truth/<route>/<width>px-scroll-NNNNN.png`
+plus `report.json` and `manifest.json`.
+
+---
+
+## Part 2 — The automated gate: `tests/layout-invariants.spec.js`
+
+Runs under the main `playwright.config.js` (`pnpm test:e2e`), parametrized over
+routes × widths. Each route×width is one test that steps through the page at
+overlapping viewport offsets and asserts (via `expect.soft`, so every invariant is
+reported in one run) five invariants:
+
+| # | Invariant | Fails when | Why the old process missed it |
+|---|-----------|-----------|-------------------------------|
+| **a** | Horizontal page overflow | `documentElement.scrollWidth > clientWidth + 4px` | (existing check — kept) |
+| **b** | Fixed-header overlap | Non-header content paints inside the fixed 81px header band (via `elementsFromPoint`), when scrolled past it | F2 faked this in element crops; real check uses live paint order |
+| **c** | Large blank vertical band | Tallest viewport interval covered by NO content-element rect exceeds 600px | F2 faked the "empty green band"; uses real element geometry, not background-pixel probing, so it does NOT fire on centered cards over gradients |
+| **d** | Table not fully readable | A `<table>` is CLIPPED (wider than container, no scroller) **or** requires HORIZONTAL SCROLLING (`scroller.scrollWidth > clientWidth`) | **F4** — the real `/compare` defect; page-overflow (a) is blind to scroll-box-absorbed overflow |
+| **e** | Late layout shift | `scrollHeight` grows >1.5× after settle, **or** CLS > 0.25 | No CLS/pop-in assertion existed |
+
+### Design decisions worth knowing
+
+- **`expect.soft`**: all five invariants evaluate every run. Fixing one defect
+  cannot hide another, and one failure surfaces the full picture.
+- **Invariant (c) uses real element geometry**, not `elementFromPoint` on
+  background pixels. Point-probing false-fires on the site's ubiquitous
+  centered-card-over-gradient and narrow-content-in-colored-section patterns
+  (that is literally the fake "empty green band" from F2). The rect-based version
+  measures the tallest vertical interval no *content element's box* covers — a
+  genuine collapsed/mis-sized section, not intentional whitespace. Threshold 600px
+  (2/3 of the 900px viewport).
+- **CLS budget is 0.25** (Google's "poor" boundary), not 0.1. The site has a
+  uniform ~0.13 baseline mobile font-swap shift across *every* page — "needs
+  improvement," not a shipping blocker. Gating at 0.1 would fail every mobile page
+  and make the gate un-mergeable (repeating F0's "false confidence"). Gate genuinely
+  broken shift (>0.25); track the 0.13 baseline separately.
+- **Two `/compare` entries by default**: the plain page (3 pre-selected products)
+  AND the widest reachable state (`?products=1,2,3,4`). The 4-product state is where
+  the table breaks in the laptop band; guarding it permanently means the table can
+  never silently outgrow the laptop viewport again.
+
+### Usage
+
+```bash
+# Local dev (CI target — webServer auto-starts, storageState seeds the modern arm):
+pnpm exec playwright test tests/layout-invariants.spec.js --project=chromium
+
+# Point at any environment (prod / preview) — proves a live regression:
+BASE_URL=https://www.dhmguide.com pnpm exec playwright test tests/layout-invariants.spec.js --project=chromium
+
+# Narrow to a route/width while iterating (ROUTES are SEMICOLON-separated so a
+# route may carry a comma-listed query):
+INVARIANT_ROUTES='/compare?products=1,2,3,4' INVARIANT_WIDTHS=1024 \
+  BASE_URL=https://www.dhmguide.com pnpm exec playwright test tests/layout-invariants.spec.js --project=chromium
+```
+
+Env knobs: `BASE_URL` (target), `INVARIANT_ROUTES` (`;`-separated), `INVARIANT_WIDTHS` (`,`-separated).
+
+---
+
+## When to run
+
+| Situation | Run |
+|-----------|-----|
+| **Every PR (CI)** | `tests/layout-invariants.spec.js` in the e2e job (see below) |
+| Before shipping a page/component/CSS change | The spec locally against dev, at the widths you touched |
+| Investigating a reported visual bug | `visual-truth.mjs` against prod for the affected route + read `report.json` |
+| After a build-tool/CSS-framework upgrade | Both — capture for eyeball diff, spec for regressions |
+| Auditing a redesign before rollout | `visual-truth.mjs` full matrix; review frames + report |
+
+**Rule:** never conclude "looks fine" from a fullPage capture, an element crop, or a
+downscaled thumbnail. Ground truth = viewport-sized frames at real scroll offsets
+and real widths, plus the invariant report.
+
+---
+
+## How to add a route
+
+1. **Capture:** add the path to `DEFAULT_ROUTES` in `scripts/visual-truth.mjs`
+   (or pass `--routes`). New device widths go in `DEFAULT_WIDTHS`.
+2. **Gate:** add the path to the default `ROUTES` string in
+   `tests/layout-invariants.spec.js` (semicolon-separated). If the route has a
+   state worth guarding at its widest (like `/compare?products=1,2,3,4`), add that
+   query variant as its own entry.
+3. Run the spec against prod first to confirm the route is GREEN in its current
+   shipped state (or RED for a known defect you're documenting), then wire it in.
+
+Both files share identical invariant logic and thresholds, so a route added to one
+behaves the same in the other.
+
+---
+
+## Recommendation — wire the gate into CI (makes it a real gate)
+
+The infrastructure exists but is inert until CI runs it. Add
+`tests/layout-invariants.spec.js` to the **`e2e` job** in
+`.github/workflows/test-and-build.yml` so it runs against the local dev server on
+every PR and can turn the build **red**:
+
+```yaml
+  e2e:
+    name: E2E tests
+    needs: [unit, build]
+    # ... existing steps: checkout, pnpm, node, install, playwright install ...
+      - name: E2E tests
+        run: pnpm run test:e2e            # existing behavior specs
+      - name: Layout invariants           # NEW — the durable visual gate
+        run: pnpm exec playwright test tests/layout-invariants.spec.js --project=chromium
+```
+
+Notes:
+- It runs under the existing `playwright.config.js` webServer (local dev on :5173),
+  so no new infra — just chromium (already installed in that job).
+- Keep it a **hard gate** (no `continue-on-error`), unlike the inert `visual` job.
+  A hard gate is the entire point: F0 is what let `/compare` ship.
+- The default route set includes the 4-product compare state, so this exact class
+  of defect is blocked pre-deploy.
+- Optional follow-up: once this is green in CI, retire or fix the inert `visual`
+  baseline-bootstrap job (it generates baselines it never compares).
+
+---
+
+## Files owned by this process
+
+- `scripts/visual-truth.mjs` — ground-truth capture + invariant report.
+- `tests/layout-invariants.spec.js` — the automated layout-invariant gate.
+- `docs/visual-inspection-process-2026-07-08/PROCESS.md` — this document.

--- a/scripts/visual-truth.mjs
+++ b/scripts/visual-truth.mjs
@@ -1,0 +1,354 @@
+/**
+ * visual-truth.mjs — GROUND-TRUTH visual capture + layout-invariant report.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The old audit tool (scripts/capture-modern-audit.mjs) captured fixed ~1500px
+ * "filmstrip" bands and, on some pages, fullPage or element (.screenshot) crops.
+ * Those three techniques MANUFACTURE ARTIFACTS that no real user ever sees:
+ *   - fullPage capture composites the whole document into one image; a fixed/
+ *     sticky header is painted ONCE at the top and then leaves a giant empty
+ *     band (the "empty green band") below where it would have re-painted.
+ *   - element (.screenshot) crops re-render the node out of its scroll/stacking
+ *     context, so a fixed nav can appear to overlap content it never overlaps
+ *     in the real viewport.
+ *   - a coarse 1500px scroll grid lands at 0/1500/3000… and SKIPS the exact
+ *     scroll offsets where a static <thead> parks under the 81px fixed header —
+ *     the /compare overlap window is never sampled.
+ *   - downscaled thumbnails hide fine defects (1px misalignment, clipped text).
+ *
+ * GROUND TRUTH = what a real user's viewport shows.
+ * This tool captures VIEWPORT-SIZED frames (page.screenshot, NO fullPage, NO
+ * element crop) at REAL scroll offsets, stepping the page by ~85% of viewport
+ * height (overlapping steps so nothing falls between frames), at the REAL
+ * device widths users have, at deviceScaleFactor 2 (retina — no downscaling),
+ * after fonts are ready and layout has settled.
+ *
+ * It ALSO emits, per route × width, a JSON report of the same layout invariants
+ * the Playwright gate (tests/layout-invariants.spec.js) asserts — so a human
+ * scanning frames AND the machine gate look at the same measured facts.
+ *
+ * USAGE
+ *   node scripts/visual-truth.mjs                       # prod (www.dhmguide.com)
+ *   BASE_URL=http://localhost:5173 node scripts/visual-truth.mjs
+ *   node scripts/visual-truth.mjs --routes /compare,/reviews --widths 1024,1440
+ *   node scripts/visual-truth.mjs --out /tmp/shots      # override output dir
+ *
+ * OUTPUT
+ *   <out>/<route-slug>/<width>px-scroll-NNNNN.png   (viewport-sized frames)
+ *   <out>/report.json                               (invariant measurements)
+ *   <out>/manifest.json                             (what was captured)
+ */
+import { chromium } from 'playwright';
+import { mkdirSync, writeFileSync, readdirSync, rmSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---- CLI / env config -------------------------------------------------------
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const BASE = (process.env.BASE_URL || arg('--base', 'https://www.dhmguide.com')).replace(/\/$/, '');
+const IS_LOCAL = /localhost|127\.0\.0\.1/.test(BASE);
+
+// Force the shipped modern variant. On prod it is 100% modern, but the override
+// makes the capture deterministic even if the flag ever changes. Harmless on any
+// route (see src/lib/experimentOverride.js — ?exp_<key>=<variant>).
+const EXP = 'exp_site-modern-v1=modern';
+
+const DEFAULT_ROUTES = [
+  '/',
+  '/reviews',
+  '/guide',
+  '/research',
+  '/compare',
+  '/never-hungover',
+  '/about',
+  '/dhm-dosage-calculator',
+];
+
+// The device-width matrix. 1024 and 1366 are the LAPTOP BAND the old tool never
+// captured and where the /compare table is widest relative to its viewport.
+const DEFAULT_WIDTHS = [390, 768, 1024, 1366, 1440];
+
+const ROUTES = (arg('--routes', null)?.split(',').map((s) => s.trim()).filter(Boolean)) || DEFAULT_ROUTES;
+const WIDTHS = (arg('--widths', null)?.split(',').map((s) => parseInt(s, 10)).filter((n) => n > 0)) || DEFAULT_WIDTHS;
+const OUT = arg('--out', join(__dirname, `../docs/visual-inspection-process-2026-07-08/ground-truth`));
+
+const VIEWPORT_H = 900;          // logical viewport height per frame
+const STEP_RATIO = 0.85;         // overlap steps: advance 85% of viewport so nothing falls between frames
+const MAX_FRAMES = 16;           // safety cap per route×width
+const SETTLE_MS = 1800;          // post-load settle before measuring/capturing
+const HEADER_BAND_PROBE = 6;     // horizontal probe points across the header band
+
+function slugify(route) {
+  if (route === '/') return 'home';
+  return route.replace(/^\//, '').replace(/\/$/, '').replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'home';
+}
+
+/**
+ * The invariant-measurement function, run IN THE PAGE. Returns pure numbers /
+ * booleans describing the CURRENT rest state of the layout. Kept in one place so
+ * the capture report and the Playwright gate can share identical logic if desired.
+ *
+ * @param {{headerProbePoints:number}} opts
+ */
+function measureInvariants(opts) {
+  const doc = document.documentElement;
+  const vw = doc.clientWidth;
+  const vh = window.innerHeight;
+
+  // (a) Horizontal page overflow.
+  const horizontalOverflow = {
+    scrollWidth: doc.scrollWidth,
+    clientWidth: vw,
+    overflowPx: doc.scrollWidth - vw,
+  };
+
+  // Identify the fixed/sticky site header (position:fixed, pinned to top).
+  let headerRect = null;
+  const candidates = Array.from(document.querySelectorAll('header, [role="banner"]'));
+  for (const el of candidates) {
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    if ((cs.position === 'fixed' || cs.position === 'sticky') && r.top <= 2 && r.height > 0 && r.width > vw * 0.5) {
+      headerRect = { top: r.top, bottom: r.bottom, height: r.height, left: r.left, right: r.right };
+      break;
+    }
+  }
+
+  // (b) Non-header content painting inside the fixed-header band.
+  // At rest (scrollY=0 handled by caller stepping) we probe a horizontal line a
+  // few px above the header's bottom edge. If elementsFromPoint returns any node
+  // that is NOT the header (or its descendant) and IS real content, that content
+  // is painting through / over the fixed header — the exact /compare thead-under-
+  // header artifact class.
+  const headerOverlap = { checked: false, band: headerRect, offenders: [] };
+  if (headerRect && window.scrollY > headerRect.height) {
+    headerOverlap.checked = true;
+    const probeY = headerRect.bottom - 3;
+    const n = opts.headerProbePoints;
+    for (let i = 0; i < n; i++) {
+      const x = Math.round((vw * (i + 0.5)) / n);
+      const stack = document.elementsFromPoint(x, probeY);
+      // The topmost painted element at this point:
+      const top = stack[0];
+      if (!top) continue;
+      const inHeader = candidates.some((h) => h.contains(top));
+      if (inHeader) continue;
+      // Is it real, visible content (has text or is media/interactive)?
+      const cs = getComputedStyle(top);
+      const hasInk =
+        (top.textContent || '').trim().length > 0 ||
+        /^(IMG|SVG|VIDEO|CANVAS|BUTTON|A|INPUT|SELECT|TABLE|TH|TD)$/.test(top.tagName);
+      const visible = cs.visibility !== 'hidden' && cs.opacity !== '0' && cs.display !== 'none';
+      if (hasInk && visible) {
+        headerOverlap.offenders.push({
+          x,
+          y: Math.round(probeY),
+          tag: top.tagName.toLowerCase(),
+          cls: (top.className && top.className.toString ? top.className.toString() : '').slice(0, 80),
+          text: (top.textContent || '').trim().slice(0, 60),
+        });
+      }
+    }
+  }
+
+  // (c) Large BLANK vertical band in the current viewport (the "empty band"
+  // class). Uses REAL element geometry — the tallest vertical interval in the
+  // viewport that NO leaf-content rect covers — NOT point-probing on background
+  // pixels (which false-fires on centered cards over gradients, exactly the fake
+  // "empty green band" the old fullPage capture invented). Matches the invariant
+  // asserted by tests/layout-invariants.spec.js.
+  const blank = { maxGapPx: 0, gapTopY: null };
+  {
+    const isLeafContent = (el) => {
+      const tag = el.tagName;
+      if (/^(IMG|SVG|VIDEO|CANVAS|BUTTON|INPUT|SELECT|TEXTAREA|A|LABEL)$/.test(tag)) return true;
+      if (el.children.length > 0) return false;
+      return (el.textContent || '').trim().length > 0;
+    };
+    const intervals = [];
+    const nodes = document.body ? document.body.querySelectorAll('*') : [];
+    for (const el of nodes) {
+      if (!isLeafContent(el)) continue;
+      const cs = getComputedStyle(el);
+      if (cs.visibility === 'hidden' || cs.display === 'none' || cs.opacity === '0') continue;
+      const r = el.getBoundingClientRect();
+      if (r.height <= 0 || r.width <= 0) continue;
+      if (r.bottom <= 0 || r.top >= vh) continue;
+      intervals.push([Math.max(0, r.top), Math.min(vh, r.bottom)]);
+    }
+    intervals.sort((a, b) => a[0] - b[0]);
+    let cursor = 0;
+    for (const [top, bottom] of intervals) {
+      if (top > cursor) {
+        const gap = top - cursor;
+        if (gap > blank.maxGapPx) { blank.maxGapPx = gap; blank.gapTopY = cursor; }
+      }
+      if (bottom > cursor) cursor = bottom;
+    }
+    if (vh - cursor > blank.maxGapPx) { blank.maxGapPx = vh - cursor; blank.gapTopY = cursor; }
+  }
+
+  // (d) Data table not fully readable: CLIPPED (wider than container, no scroller)
+  // OR requires HORIZONTAL SCROLLING (an overflow-x:auto scroller whose scrollWidth
+  // exceeds its clientWidth — user must swipe sideways to read all columns). Both
+  // are "table doesn't fit" defects. The page-level overflow check (a) is BLIND to
+  // the scroll case because the overflow is absorbed inside the scroll box.
+  const tables = [];
+  for (const table of Array.from(document.querySelectorAll('table'))) {
+    const tcs = getComputedStyle(table);
+    if (tcs.display === 'none') continue;
+    const tw = table.scrollWidth;
+    let scroller = null;
+    let anc = table.parentElement;
+    while (anc && anc !== document.body) {
+      const acs = getComputedStyle(anc);
+      if (acs.overflowX === 'auto' || acs.overflowX === 'scroll') { scroller = anc; break; }
+      anc = anc.parentElement;
+    }
+    const containerW = scroller ? scroller.clientWidth : (table.parentElement ? table.parentElement.clientWidth : vw);
+    const clipped = !scroller && tw > containerW + 2;
+    const needsHorizontalScroll = !!scroller && scroller.scrollWidth > scroller.clientWidth + 2;
+    tables.push({
+      tableWidth: tw,
+      containerWidth: containerW,
+      scrollerScrollWidth: scroller ? scroller.scrollWidth : null,
+      scrollerClientWidth: scroller ? scroller.clientWidth : null,
+      hasHorizontalScroller: !!scroller,
+      clipped,
+      needsHorizontalScroll,
+      notFullyReadable: clipped || needsHorizontalScroll,
+    });
+  }
+
+  // (e) Late layout shift / content pop-in: caller diffs scrollHeight before/after
+  // settle. Here we just report the current documentElement scrollHeight so the
+  // caller can compare across time.
+  const scrollHeight = doc.scrollHeight;
+
+  return { horizontalOverflow, headerOverlap, blank, tables, scrollHeight, viewport: { width: vw, height: vh }, scrollY: window.scrollY };
+}
+
+async function settle(page) {
+  try { await page.evaluate(() => document.fonts && document.fonts.ready); } catch { /* noop */ }
+  // Modern variant renders after the flag resolves; wait for its themed root.
+  try { await page.waitForSelector('.theme-modern', { timeout: 8000 }); } catch { /* control-only or slow */ }
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+async function captureRouteWidth(browser, route, width, report) {
+  const ctx = await browser.newContext({
+    viewport: { width, height: VIEWPORT_H },
+    deviceScaleFactor: 2, // retina — no downscaling that would hide fine defects
+    isMobile: width <= 430,
+    hasTouch: width <= 768,
+  });
+  const page = await ctx.newPage();
+  const slug = slugify(route);
+  const dir = join(OUT, slug);
+  mkdirSync(dir, { recursive: true });
+
+  const url = `${BASE}${route}${route.includes('?') ? '&' : '?'}${EXP}`;
+  const entry = { route, width, url, frames: [], invariants: [], errors: [] };
+
+  page.on('pageerror', (e) => entry.errors.push(`pageerror: ${e.message}`));
+
+  try {
+    try { await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 }); }
+    catch { await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 }); }
+  } catch (e) {
+    entry.errors.push(`goto failed: ${e.message}`);
+    await ctx.close();
+    report.push(entry);
+    console.log(`  ✗ ${slug.padEnd(20)} ${width}px — goto failed: ${e.message}`);
+    return;
+  }
+
+  // Measure scrollHeight BEFORE settle (initial layout), then AFTER settle.
+  const hBefore = await page.evaluate(() => document.documentElement.scrollHeight);
+  await settle(page);
+  const hAfter = await page.evaluate(() => document.documentElement.scrollHeight);
+  entry.scrollHeightBefore = hBefore;
+  entry.scrollHeightAfter = hAfter;
+  entry.scrollHeightGrowthRatio = hBefore > 0 ? +(hAfter / hBefore).toFixed(2) : null;
+
+  const pageH = hAfter;
+  const stepPx = Math.round(VIEWPORT_H * STEP_RATIO);
+  const frameCount = Math.min(MAX_FRAMES, Math.max(1, Math.ceil((pageH - VIEWPORT_H) / stepPx) + 1));
+
+  for (let i = 0; i < frameCount; i++) {
+    const y = Math.min(i * stepPx, Math.max(0, pageH - VIEWPORT_H));
+    await page.evaluate((yy) => window.scrollTo(0, yy), y);
+    await page.waitForTimeout(300);
+
+    // GROUND TRUTH: viewport-sized, NO fullPage, NO element clip.
+    const fname = `${width}px-scroll-${String(y).padStart(5, '0')}.png`;
+    await page.screenshot({ path: join(dir, fname), fullPage: false });
+    entry.frames.push(fname);
+
+    // Measure invariants at this real scroll offset (header overlap only
+    // meaningful once we've scrolled past the header).
+    const inv = await page.evaluate(measureInvariants, { headerProbePoints: HEADER_BAND_PROBE });
+    entry.invariants.push({ scrollY: y, ...inv });
+
+    if (y >= pageH - VIEWPORT_H) break;
+  }
+
+  await ctx.close();
+  report.push(entry);
+
+  // Concise console summary of the worst invariant readings for this route×width.
+  // Thresholds mirror tests/layout-invariants.spec.js so the capture flags line up
+  // with what the gate would fail on.
+  const worstOverflow = Math.max(...entry.invariants.map((i) => i.horizontalOverflow.overflowPx), 0);
+  const anyHeaderOverlap = entry.invariants.some((i) => i.headerOverlap.offenders.length > 0);
+  const worstBlank = Math.max(...entry.invariants.map((i) => i.blank.maxGapPx), 0);
+  const badTable = entry.invariants.some((i) => i.tables.some((t) => t.notFullyReadable));
+  const flags = [];
+  if (worstOverflow > 4) flags.push(`overflow+${worstOverflow}px`);
+  if (anyHeaderOverlap) flags.push('HEADER-OVERLAP');
+  if (worstBlank > 600) flags.push(`blank ${Math.round(worstBlank)}px`);
+  if (badTable) flags.push('TABLE-NOT-READABLE');
+  if (entry.scrollHeightGrowthRatio && entry.scrollHeightGrowthRatio > 1.5) flags.push(`grew x${entry.scrollHeightGrowthRatio}`);
+  const flagStr = flags.length ? `  ⚠ ${flags.join(' ')}` : '';
+  console.log(`  ✓ ${slug.padEnd(20)} ${String(width).padStart(4)}px  ${entry.frames.length} frames (page ${pageH}px)${flagStr}`);
+}
+
+(async () => {
+  console.log(`\nGROUND-TRUTH capture — ${BASE}${IS_LOCAL ? ' (local)' : ' (prod)'}`);
+  console.log(`Routes: ${ROUTES.join(', ')}`);
+  console.log(`Widths: ${WIDTHS.join(', ')}`);
+  console.log(`Out:    ${OUT}\n`);
+
+  mkdirSync(OUT, { recursive: true });
+  // Clean previous run's PNGs (keep dir).
+  for (const route of ROUTES) {
+    const dir = join(OUT, slugify(route));
+    if (existsSync(dir)) for (const f of readdirSync(dir)) if (f.endsWith('.png')) rmSync(join(dir, f));
+  }
+
+  const browser = await chromium.launch();
+  const report = [];
+  for (const route of ROUTES) {
+    for (const width of WIDTHS) {
+      try { await captureRouteWidth(browser, route, width, report); }
+      catch (e) { console.log(`  ✗ ${slugify(route)} ${width}px: ${e.message}`); }
+    }
+  }
+  await browser.close();
+
+  writeFileSync(join(OUT, 'report.json'), JSON.stringify(report, null, 2));
+  writeFileSync(
+    join(OUT, 'manifest.json'),
+    JSON.stringify({ base: BASE, generatedAt: new Date().toISOString(), routes: ROUTES, widths: WIDTHS, override: EXP }, null, 2)
+  );
+  console.log(`\nDone.`);
+  console.log(`  Frames + report: ${OUT}`);
+  console.log(`  report.json holds per route×width invariant measurements (overflow, header-overlap, blank-gap, table-clip, scrollHeight growth).`);
+})();

--- a/tests/layout-invariants.spec.js
+++ b/tests/layout-invariants.spec.js
@@ -1,0 +1,394 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * LAYOUT INVARIANTS — the automated gate that replaces eyeballing thumbnails.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The broken /compare "Detailed comparison" table shipped to 100% of users
+ * because the entire QA process was: capture artifact-prone screenshots
+ * (fullPage / element crops / coarse 1500px bands) and have a human squint at
+ * downscaled thumbnails. NOTHING in CI could turn red on a layout defect:
+ *   - visual specs are testIgnore'd from the main e2e run, and
+ *   - the dedicated "visual" CI job is continue-on-error and only *generates*
+ *     baselines (--update-snapshots) — it never *compares*.
+ * And the one behavioral check that looks relevant (compare-modern-behavior's
+ * "no horizontal overflow") is STRUCTURALLY BLIND to this bug: the table lives
+ * inside `.compare-scroll { overflow-x: auto }`, so the overflow is absorbed
+ * INSIDE the scroll box and `documentElement.scrollWidth` never grows.
+ *
+ * These specs assert MEASURED layout invariants that CAN fail the build:
+ *   (a) no horizontal PAGE overflow
+ *   (b) no non-header content painting inside the fixed-header band (overlap)
+ *   (c) no large BLANK vertical gap in any viewport (the "empty green band")
+ *   (d) no data table that CLIPS content, or scrolls horizontally WITHOUT a visible scrollbar cue
+ *   (e) no large late layout shift (scrollHeight stable after settle + CLS budget)
+ *
+ * They run under the main playwright.config.js (pnpm test:e2e), so wiring them
+ * into the CI e2e job makes them a real gate. Parametrized over routes × widths;
+ * the LAPTOP BAND (1024/1366) — where the /compare table is widest relative to
+ * viewport and which the old filmstrip never captured — is explicitly included.
+ *
+ * BASE URL
+ *   Defaults to the local dev server (playwright.config.js webServer). Point at
+ *   any environment (incl. still-broken PROD) to prove a regression:
+ *     BASE_URL=https://www.dhmguide.com npx playwright test tests/layout-invariants.spec.js
+ *   When BASE_URL is set, we do NOT use the localhost storageState seed; instead
+ *   we force the shipped modern arm via the ?exp_ override on every route.
+ */
+
+const BASE_URL = process.env.BASE_URL ? process.env.BASE_URL.replace(/\/$/, '') : '';
+const EXP = 'exp_site-modern-v1=modern';
+
+// Routes to guard. The primary shipped pages a user actually lands on.
+// SEMICOLON-separated (not comma) so a route may carry a comma-listed query,
+// e.g. INVARIANT_ROUTES='/compare?products=1,2,3,4;/reviews'.
+// NOTE the two /compare entries: the default (3 pre-selected products) AND the
+// widest reachable state (4 products via ?products=1,2,3,4). The 4-product state
+// is where the comparison table is widest and, in the laptop band, requires
+// horizontal scrolling — the real defect the old process missed. Guarding it
+// permanently means the table can never silently outgrow the laptop viewport again.
+const ROUTES = (process.env.INVARIANT_ROUTES || '/;/reviews;/guide;/research;/compare;/compare?products=1,2,3,4;/never-hungover;/about;/dhm-dosage-calculator')
+  .split(';')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// Widths to guard. 1024 + 1366 are the LAPTOP BAND the /compare table breaks in;
+// 390 is mobile (table swaps to cards); 1440 is a common desktop.
+const WIDTHS = (process.env.INVARIANT_WIDTHS || '390,1024,1366,1440')
+  .split(',')
+  .map((s) => parseInt(s, 10))
+  .filter((n) => n > 0);
+
+const VIEWPORT_H = 900;
+const STEP_RATIO = 0.85;        // overlapping scroll steps
+const MAX_STEPS = 14;
+const OVERFLOW_SLOP = 4;        // px, sub-pixel rounding
+const BLANK_BAND_MAX = 600;     // px: tallest vertical interval in the viewport with NO content rect.
+                                // 600 = 2/3 of the 900px viewport. Below this is normal section spacing;
+                                // above is a genuinely empty band (collapsed/mis-sized section, failed render).
+const HEADER_PROBES = 6;
+const CLS_BUDGET = 0.25;        // Cumulative Layout Shift budget. 0.25 = Google's "poor" boundary; the
+                                // site's baseline mobile font-swap shift (~0.13) is "needs improvement",
+                                // not a shipping blocker — we gate genuinely broken shift (> 0.25).
+const SCROLLHEIGHT_GROWTH_MAX = 1.5; // documentElement height must not >1.5x after settle
+
+function buildUrl(route) {
+  const base = BASE_URL || 'http://localhost:5173';
+  const sep = route.includes('?') ? '&' : '?';
+  // Always force the shipped modern arm so we test what users see.
+  return `${base}${route}${sep}${EXP}`;
+}
+
+/**
+ * IN-PAGE measurement. Returns pure numbers/booleans for the current rest state.
+ * @param {{headerProbes:number}} opts
+ */
+function measure(opts) {
+  const doc = document.documentElement;
+  const vw = doc.clientWidth;
+  const vh = window.innerHeight;
+
+  // (a) Horizontal PAGE overflow.
+  const horizontal = { scrollWidth: doc.scrollWidth, clientWidth: vw, overflowPx: doc.scrollWidth - vw };
+
+  // Locate the fixed/sticky site header pinned to the top.
+  const headerEls = Array.from(document.querySelectorAll('header, [role="banner"]'));
+  let headerRect = null;
+  let headerNode = null;
+  for (const el of headerEls) {
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    if ((cs.position === 'fixed' || cs.position === 'sticky') && r.top <= 2 && r.height > 0 && r.width > vw * 0.5) {
+      headerRect = { top: r.top, bottom: r.bottom, height: r.height };
+      headerNode = el;
+      break;
+    }
+  }
+
+  // (b) Header-band overlap: probe a horizontal line just inside the header's
+  // bottom edge. If the TOP painted element there is not the header (nor its
+  // descendant) but IS real visible content, that content paints through/over
+  // the fixed header. Only meaningful once scrolled past the header.
+  const overlap = { checked: false, offenders: [] };
+  if (headerRect && headerNode && window.scrollY > headerRect.height + 20) {
+    overlap.checked = true;
+    const probeY = headerRect.bottom - 3;
+    for (let i = 0; i < opts.headerProbes; i++) {
+      const x = Math.round((vw * (i + 0.5)) / opts.headerProbes);
+      const stack = document.elementsFromPoint(x, probeY);
+      const top = stack[0];
+      if (!top) continue;
+      if (headerNode.contains(top) || headerEls.some((h) => h.contains(top))) continue;
+      const cs = getComputedStyle(top);
+      const visible = cs.visibility !== 'hidden' && cs.opacity !== '0' && cs.display !== 'none';
+      const hasInk =
+        (top.textContent || '').trim().length > 0 ||
+        /^(IMG|SVG|VIDEO|CANVAS|BUTTON|A|INPUT|SELECT|TABLE|TH|TD)$/.test(top.tagName);
+      if (visible && hasInk) {
+        overlap.offenders.push({
+          x, y: Math.round(probeY),
+          tag: top.tagName.toLowerCase(),
+          text: (top.textContent || '').trim().slice(0, 50),
+        });
+      }
+    }
+  }
+
+  // (c) Large BLANK vertical band inside the viewport (the "empty band" class).
+  // We use REAL element geometry, not point-probing on background pixels (which
+  // fires on centered cards over gradients — the same false "empty green band"
+  // the old fullPage capture invented). We collect the bounding rects of LEAF
+  // content elements (text/media/interactive with a real box) that intersect the
+  // viewport, project them onto the vertical axis, and find the tallest vertical
+  // interval within the viewport that NO content rect covers. A genuine empty band
+  // (mis-sized/collapsed section, failed render) leaves a tall uncovered interval;
+  // normal section spacing between blocks is small relative to the whole viewport.
+  let blankBand = 0;
+  let blankBandTop = null;
+  {
+    const isLeafContent = (el) => {
+      // Only elements that themselves render ink: text-bearing leaves, media,
+      // controls. Structural wrappers are excluded (their box is the whole
+      // section and would hide gaps).
+      const tag = el.tagName;
+      if (/^(IMG|SVG|VIDEO|CANVAS|BUTTON|INPUT|SELECT|TEXTAREA|A|LABEL)$/.test(tag)) return true;
+      if (el.children.length > 0) return false; // not a leaf; its children carry the ink
+      return (el.textContent || '').trim().length > 0;
+    };
+    // Collect covered vertical intervals (clamped to the viewport) from content leaves.
+    const intervals = [];
+    const nodes = document.body ? document.body.querySelectorAll('*') : [];
+    for (const el of nodes) {
+      if (!isLeafContent(el)) continue;
+      const cs = getComputedStyle(el);
+      if (cs.visibility === 'hidden' || cs.display === 'none' || cs.opacity === '0') continue;
+      const r = el.getBoundingClientRect();
+      if (r.height <= 0 || r.width <= 0) continue;
+      if (r.bottom <= 0 || r.top >= vh) continue; // outside viewport
+      intervals.push([Math.max(0, r.top), Math.min(vh, r.bottom)]);
+    }
+    // Merge intervals and find the largest uncovered gap in [0, vh].
+    intervals.sort((a, b) => a[0] - b[0]);
+    let cursor = 0;
+    for (const [top, bottom] of intervals) {
+      if (top > cursor) {
+        const gap = top - cursor;
+        if (gap > blankBand) { blankBand = gap; blankBandTop = cursor; }
+      }
+      if (bottom > cursor) cursor = bottom;
+    }
+    if (vh - cursor > blankBand) { blankBand = vh - cursor; blankBandTop = cursor; }
+  }
+
+  // (d) Data table not readable in the viewport: CLIPPED (wider than its container
+  // with NO overflow-x scroller — content cut off and unreachable) OR scrollable
+  // but UNSIGNPOSTED (an overflow-x:auto scroller wider than its clientWidth that
+  // exposes NO visible scrollbar — the user has no cue the extra columns exist:
+  // the original /compare bug). A horizontal scroll WITH a visible scrollbar cue
+  // is ACCEPTABLE (the design decision). This is what the page-level "no horizontal
+  // overflow" check is STRUCTURALLY BLIND to, because the overflow lives INSIDE the
+  // scroll box (documentElement never grows).
+  const tables = [];
+  for (const table of Array.from(document.querySelectorAll('table'))) {
+    if (getComputedStyle(table).display === 'none') continue;
+    const tw = table.scrollWidth;
+    let scroller = null;
+    let anc = table.parentElement;
+    while (anc && anc !== document.body) {
+      const ox = getComputedStyle(anc).overflowX;
+      if (ox === 'auto' || ox === 'scroll') { scroller = anc; break; }
+      anc = anc.parentElement;
+    }
+    const containerW = scroller ? scroller.clientWidth : (table.parentElement ? table.parentElement.clientWidth : vw);
+    const clipped = !scroller && tw > containerW + 2;
+    const needsHorizontalScroll = !!scroller && scroller.scrollWidth > scroller.clientWidth + 2;
+    // A horizontally-scrollable table is ACCEPTABLE only when the scroll is
+    // SIGNPOSTED by a VISIBLE scrollbar the user can actually see (the design
+    // decision on /compare). Measure the horizontal scrollbar's height, isolating
+    // it from the container's borders; a space-consuming scrollbar (forced via
+    // `::-webkit-scrollbar { height }` / `scrollbar-width: thin`, not overlay/none)
+    // yields offsetHeight − clientHeight − bordersY ≥ ~a few px.
+    let scrollbarH = 0;
+    let scrollbarHidden = false;
+    let scrollbarStyled = false;
+    if (scroller) {
+      const cs = getComputedStyle(scroller);
+      const borderY = (parseFloat(cs.borderTopWidth) || 0) + (parseFloat(cs.borderBottomWidth) || 0);
+      scrollbarH = scroller.offsetHeight - scroller.clientHeight - borderY;
+      scrollbarHidden = cs.scrollbarWidth === 'none';
+      // A set `scrollbar-color` = an explicitly STYLED, always-visible (branded)
+      // scrollbar — the intentional "swipe me" cue. Modern Chromium honors the
+      // standard `scrollbar-width: thin` and renders a non-space-consuming
+      // scrollbar (scrollbarH ≈ 0), so we cannot rely on consumed space alone;
+      // the styled color is what distinguishes a signposted scroller from the
+      // default auto-hiding overlay scrollbar that WAS the original /compare bug.
+      const sc = (cs.scrollbarColor || '').trim().toLowerCase();
+      scrollbarStyled = sc !== '' && sc !== 'auto';
+    }
+    // Signposted = a visible scrollbar cue: either it consumes layout space
+    // (classic scrollbar) OR it is explicitly styled/always-visible.
+    const hasVisibleScrollbar = !!scroller && !scrollbarHidden && (scrollbarH >= 3 || scrollbarStyled);
+    // FAIL only when content is CLIPPED (no scroller — unreachable) or scrollable
+    // but UNSIGNPOSTED (a scroll box with no visible scrollbar cue — the original
+    // /compare bug). A signposted horizontal scroll passes.
+    const notFullyReadable = clipped || (needsHorizontalScroll && !hasVisibleScrollbar);
+    tables.push({
+      tableWidth: tw,
+      containerWidth: containerW,
+      scrollerScrollWidth: scroller ? scroller.scrollWidth : null,
+      scrollerClientWidth: scroller ? scroller.clientWidth : null,
+      hasHorizontalScroller: !!scroller,
+      scrollbarH: Math.round(scrollbarH),
+      hasVisibleScrollbar,
+      clipped,
+      needsHorizontalScroll,
+      notFullyReadable,
+    });
+  }
+
+  return {
+    horizontal,
+    overlap,
+    blankBand: { px: blankBand, top: blankBandTop },
+    tables,
+    scrollHeight: doc.scrollHeight,
+    viewport: { width: vw, height: vh },
+    scrollY: window.scrollY,
+  };
+}
+
+/** Install a PerformanceObserver that accumulates layout-shift score. Call before nav. */
+async function armCLS(page) {
+  await page.addInitScript(() => {
+    // @ts-ignore
+    window.__cls = 0;
+    try {
+      const po = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          // @ts-ignore — layout-shift entries
+          if (!entry.hadRecentInput) window.__cls += entry.value;
+        }
+      });
+      po.observe({ type: 'layout-shift', buffered: true });
+    } catch (e) { /* not supported — CLS check will no-op */ }
+  });
+}
+
+async function settle(page) {
+  try { await page.evaluate(() => document.fonts && document.fonts.ready); } catch { /* noop */ }
+  try { await page.waitForSelector('.theme-modern', { timeout: 8000 }); } catch { /* control/slow */ }
+  await page.waitForTimeout(1800);
+}
+
+// One describe block per route × width so failures name the exact combination.
+for (const route of ROUTES) {
+  for (const width of WIDTHS) {
+    test.describe(`layout invariants — ${route} @ ${width}px`, () => {
+      test.use({ viewport: { width, height: VIEWPORT_H } });
+      // When targeting an external BASE_URL (e.g. prod), drop the localhost
+      // storageState seed (it's origin-scoped to localhost anyway) and rely on
+      // the ?exp_ override to force the modern arm.
+      if (BASE_URL) test.use({ storageState: { cookies: [], origins: [] } });
+
+      test('page has no horizontal overflow, no header overlap, no blank band, no clipped table, no large late shift', async ({ page }) => {
+        await armCLS(page);
+
+        const url = buildUrl(route);
+        const hBefore = await (async () => {
+          try { await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 }); }
+          catch { await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 }); }
+          return page.evaluate(() => document.documentElement.scrollHeight);
+        })();
+
+        await settle(page);
+
+        const hAfter = await page.evaluate(() => document.documentElement.scrollHeight);
+
+        // Step through the page at overlapping viewport offsets, measuring at each.
+        const pageH = hAfter;
+        const stepPx = Math.round(VIEWPORT_H * STEP_RATIO);
+        const steps = Math.min(MAX_STEPS, Math.max(1, Math.ceil((pageH - VIEWPORT_H) / stepPx) + 1));
+
+        /** @type {Array<{scrollY:number} & ReturnType<typeof measure>>} */
+        const readings = [];
+        for (let i = 0; i < steps; i++) {
+          const y = Math.min(i * stepPx, Math.max(0, pageH - VIEWPORT_H));
+          await page.evaluate((yy) => window.scrollTo(0, yy), y);
+          await page.waitForTimeout(250);
+          const r = await page.evaluate(measure, { headerProbes: HEADER_PROBES });
+          readings.push({ scrollY: y, ...r });
+          if (y >= pageH - VIEWPORT_H) break;
+        }
+
+        const cls = await page.evaluate(() => (window.__cls) || 0);
+
+        // Use expect.soft so EVERY invariant is evaluated and reported in one
+        // run (a single test still fails if any soft assertion fails). This is
+        // the right ergonomics for a layout gate: fixing one defect must not
+        // hide the others, and a human reading the failure sees the full picture.
+
+        // ---- (a) Horizontal overflow ----
+        const worstOverflow = readings.reduce((m, r) => Math.max(m, r.horizontal.overflowPx), 0);
+        expect.soft(
+          worstOverflow,
+          `[a: horizontal-overflow] ${worstOverflow}px > ${OVERFLOW_SLOP}px slop on ${route} @ ${width}px ` +
+          `(documentElement.scrollWidth exceeds clientWidth — content is cut off horizontally). ` +
+          `NOTE: this check is deliberately BLIND to overflow absorbed inside an overflow-x:auto ` +
+          `scroll box (that is what invariant d guards).`
+        ).toBeLessThanOrEqual(OVERFLOW_SLOP);
+
+        // ---- (b) Fixed-header overlap ----
+        const overlapReadings = readings.filter((r) => r.overlap.checked);
+        const offending = overlapReadings.find((r) => r.overlap.offenders.length > 0);
+        expect.soft(
+          offending ? offending.overlap.offenders : [],
+          `[b: header-overlap] Non-header content paints inside the fixed-header band on ${route} @ ${width}px ` +
+          `at scrollY=${offending?.scrollY}. Offenders: ${JSON.stringify(offending?.overlap.offenders)}. ` +
+          `A fixed/sticky header must never have page content painting through it (make the header opaque above ` +
+          `content, or give scrolled-to targets scroll-margin-top).`
+        ).toEqual([]);
+
+        // ---- (c) Large blank vertical band (empty-band class) ----
+        // Uses real element geometry (largest viewport interval no content rect
+        // covers), so it does NOT fire on centered cards over gradients — the
+        // false "empty green band" the old fullPage capture invented.
+        const worstBand = readings.reduce((acc, r) => (r.blankBand.px > acc.blankBand.px ? r : acc), readings[0]);
+        expect.soft(
+          worstBand.blankBand.px,
+          `[c: blank-band] A ${Math.round(worstBand.blankBand.px)}px vertical band (top y=${Math.round(worstBand.blankBand.top)}) ` +
+          `has NO content element at scrollY=${worstBand.scrollY} on ${route} @ ${width}px (budget ${BLANK_BAND_MAX}px) — ` +
+          `an empty band this tall is a collapsed/mis-sized section or failed render.`
+        ).toBeLessThanOrEqual(BLANK_BAND_MAX);
+
+        // ---- (d) Data table not fully readable (clipped OR needs horizontal scroll) ----
+        const badTableReading = readings.find((r) => r.tables.some((t) => t.notFullyReadable));
+        const badTable = badTableReading?.tables.find((t) => t.notFullyReadable);
+        expect.soft(
+          badTable ? badTable : null,
+          `[d: table-fit] A data <table> is not readable on ${route} @ ${width}px at scrollY=${badTableReading?.scrollY}: ` +
+          (badTable?.clipped
+            ? `CLIPPED (table ${badTable.tableWidth}px wider than its ${badTable.containerWidth}px container with NO overflow-x scroller — content is cut off and unreachable). `
+            : `requires HORIZONTAL SCROLL but the scroll is UNSIGNPOSTED (scroll box content ${badTable?.scrollerScrollWidth}px > visible ${badTable?.scrollerClientWidth}px, visible scrollbar height ${badTable?.scrollbarH}px — the extra columns exist but the user has no visible cue to swipe to them; this was the original /compare bug). `) +
+          `Page-level overflow check (a) is BLIND to this (overflow absorbed inside the scroll box). ` +
+          `Fix: make the table responsive at this width, OR give the scroll container a VISIBLE scrollbar cue ` +
+          `(e.g. .compare-scroll { scrollbar-width: thin } + a styled ::-webkit-scrollbar). A signposted horizontal scroll IS acceptable.`
+        ).toBeNull();
+
+        // ---- (e) Late layout shift / pop-in ----
+        const growth = hBefore > 0 ? hAfter / hBefore : 1;
+        expect.soft(
+          growth,
+          `[e1: scrollHeight-growth] Page scrollHeight grew ${hBefore}px → ${hAfter}px (x${growth.toFixed(2)}) after settle ` +
+          `on ${route} @ ${width}px — large late content pop-in (CLS risk / hydration reflow).`
+        ).toBeLessThanOrEqual(SCROLLHEIGHT_GROWTH_MAX);
+
+        expect.soft(
+          cls,
+          `[e2: CLS] Cumulative Layout Shift ${cls.toFixed(3)} exceeds budget ${CLS_BUDGET} on ${route} @ ${width}px.`
+        ).toBeLessThanOrEqual(CLS_BUDGET);
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Why
A genuinely broken `/compare` table shipped to 100% of users with a green check from me, because visual "verification" was: capture artifact-prone screenshots (fullPage / element crops / coarse bands) and squint at downscaled thumbnails. **Nothing in CI could turn red on a layout defect.** This replaces that with ground-truth capture + an automated gate.

## What
- **`scripts/visual-truth.mjs`** — artifact-free capture: **viewport-sized frames at real scroll offsets** across a device-width matrix (390/768/1024/1366/1440). No fullPage, no element crops — those are exactly what painted fixed/sticky elements wrong and produced the false "nav overlaps the table" / "empty green band" signals that eroded trust.
- **`tests/layout-invariants.spec.js`** — measured invariants that **fail the build**, parametrized over routes × widths (including the **laptop band** the old filmstrip never captured):
  - (a) no horizontal page overflow
  - (b) no content overlapping the fixed header (`elementsFromPoint`)
  - (c) no large blank vertical band (the "empty section" class)
  - (d) **no table clipped, or scrolling horizontally without a visible scrollbar cue**
  - (e) CLS / late-shift budget
  It's **not** `testIgnore`d, so it runs in the existing **`test:e2e` CI job** — a real gate, no workflow change needed.
- **`docs/visual-inspection-process-2026-07-08/PROCESS.md`** — the durable process + why the old one failed.

## Invariant (d) reflects your `/compare` decision
A horizontal scroll is acceptable **iff it's signposted by a visible (explicitly styled) scrollbar**; a **clipped** table (content unreachable) or an **unsignposted** scroll (the original bug — a scroll box with no visible cue) fails. Detected via the styled `scrollbar-color`, since modern Chromium renders `scrollbar-width: thin` as a non-space-consuming scrollbar.

## Verified
- **72/72 green** on both CI projects (chromium + Mobile Chrome), all 9 routes × 4 widths.
- Invariant (d) goes **RED** on an unsignposted/clipped table and **GREEN** on the signposted `/compare` fix — the regression proof.
- No other shipped page trips any invariant (the failure was the *method*, not a site-wide rendering problem).