### PR TITLE
feat(blog): restyle blog post template to modern + callout/prose primitives (#384/#381)

### DIFF
--- a/src/newblog/components/KeyTakeaways.jsx
+++ b/src/newblog/components/KeyTakeaways.jsx
@@ -10,21 +10,33 @@ const KeyTakeaways = ({ takeaways }) => {
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
-      className="bg-gradient-to-br from-green-50 to-blue-50 border border-green-200 rounded-xl p-6 mb-8 shadow-lg"
+      className="not-prose card"
+      style={{
+        backgroundColor: 'var(--color-brand-soft)',
+        borderLeft: '3px solid var(--color-brand)',
+        marginBottom: 'var(--space-8)',
+      }}
     >
       <div className="flex items-center gap-3 mb-4">
-        <motion.div 
+        <motion.div
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
           transition={{ type: "spring", stiffness: 200, delay: 0.2 }}
-          className="p-2 bg-green-600 rounded-lg"
+          style={{
+            display: 'inline-flex',
+            padding: '0.5rem',
+            borderRadius: 'var(--radius-sm)',
+            backgroundColor: 'var(--color-brand)',
+          }}
         >
-          <Zap className="w-5 h-5 text-white" />
+          <Zap className="w-5 h-5" style={{ color: 'var(--color-on-brand)' }} aria-hidden="true" />
         </motion.div>
-        <h3 className="text-xl font-bold text-gray-900">Key Takeaways</h3>
+        <h3 style={{ fontFamily: 'var(--font-display)', fontSize: '1.25rem', color: 'var(--color-ink)', margin: 0 }}>
+          Key Takeaways
+        </h3>
       </div>
-      
-      <ul className="space-y-3">
+
+      <ul className="space-y-3" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
         {takeaways.map((takeaway, index) => (
           <motion.li
             key={index}
@@ -33,8 +45,8 @@ const KeyTakeaways = ({ takeaways }) => {
             transition={{ duration: 0.3, delay: 0.3 + index * 0.1 }}
             className="flex items-start gap-3"
           >
-            <CheckCircle className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
-            <span className="text-gray-700 leading-relaxed">{takeaway}</span>
+            <CheckCircle className="w-5 h-5 mt-0.5 flex-shrink-0" style={{ color: 'var(--color-brand)' }} aria-hidden="true" />
+            <span style={{ color: 'var(--color-ink)', lineHeight: 1.6 }}>{takeaway}</span>
           </motion.li>
         ))}
       </ul>

--- a/src/newblog/components/NewBlogPost.jsx
+++ b/src/newblog/components/NewBlogPost.jsx
@@ -2,11 +2,6 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Calendar, Clock, Tag, ArrowLeft, Share2, List, User, ExternalLink, ChevronRight, Loader2, Info, AlertCircle, CheckCircle, Lightbulb, Leaf } from 'lucide-react';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.jsx';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx';
-import { Badge } from '@/components/ui/badge.jsx';
-import { Button } from '@/components/ui/button.jsx';
-import { Separator } from '@/components/ui/separator.jsx';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.jsx';
 import {
   getPostBySlug,
@@ -24,6 +19,8 @@ import { Link as CustomLink } from '../../components/CustomLink';
 import { trackElementClick } from '../../lib/posthog';
 import { motion } from 'framer-motion';
 import InlineComparisonTable from '../../components/InlineComparisonTable';
+import { preloadModernFonts } from '../../lib/preloadModernFonts.js';
+import '../../styles/theme-modern.css';
 
 // Matches <!-- inline-comparison-table:VARIANT:PLACEMENT:ID,ID,ID --> in markdown.
 // Capture groups: 1=variant, 2=placement, 3=id list (comma-separated).
@@ -57,11 +54,29 @@ const InlineReviewsCTA = ({ placement, postSlug }) => {
   };
 
   return (
-    <div className="my-8 p-5 bg-gradient-to-r from-green-50 to-emerald-50 border-l-4 border-green-600 rounded-r-lg not-prose">
-      <p className="text-base md:text-lg font-semibold text-gray-900 mb-1">
+    <div
+      className="not-prose card"
+      style={{
+        marginBlock: 'var(--space-8)',
+        backgroundColor: 'var(--color-brand-soft)',
+        borderLeft: '3px solid var(--color-brand)',
+      }}
+    >
+      <p
+        style={{
+          margin: '0 0 var(--space-1)',
+          fontFamily: 'var(--font-display)',
+          fontSize: '1.125rem',
+          fontWeight: 600,
+          color: 'var(--color-ink)',
+        }}
+      >
         Looking for the best DHM supplement?
       </p>
-      <p className="text-sm text-gray-700 mb-3">
+      <p
+        className="text-soft"
+        style={{ margin: '0 0 var(--space-3)', fontSize: 'var(--text-small)' }}
+      >
         We've independently tested 10+ products for purity, absorption, and value.
       </p>
       <CustomLink
@@ -70,11 +85,45 @@ const InlineReviewsCTA = ({ placement, postSlug }) => {
         data-element-name="blog_template_reviews_cta"
         data-placement={placement}
         onClick={handleClick}
-        className="inline-flex items-center gap-1 text-green-700 hover:text-green-800 font-semibold underline underline-offset-2 min-h-[44px]"
+        className="btn btn-secondary"
+        style={{ color: 'var(--color-brand-strong)' }}
       >
         See our top-rated picks
         <ChevronRight className="w-4 h-4" />
       </CustomLink>
+    </div>
+  );
+};
+
+/**
+ * In-article callout — the modern border-first replacement for the shadcn
+ * <Alert>/green-gradient boxes the control template used. Uses the scoped
+ * .callout primitives from theme-modern.css (icon + title + body, 1px border +
+ * 3px accent rule). Variant → semantic mapping (per #384):
+ *   note (blue)    — Info Box / Did You Know / Important Medical Information
+ *   tip (green)    — Pro Tip
+ *   warning (amber)— Warning / Important / Emergency Protocol
+ *   key (ink)      — Key Insight
+ * Orange is never emitted here — it stays exclusive to affiliate/buy CTAs.
+ */
+const CALLOUT_ICONS = {
+  note: Info,
+  tip: CheckCircle,
+  warning: AlertCircle,
+  key: Lightbulb,
+};
+
+const Callout = ({ variant = 'note', title, children }) => {
+  const Icon = CALLOUT_ICONS[variant] || Info;
+  return (
+    <div className={`not-prose callout callout--${variant}`} role="note">
+      <span className="callout__icon" aria-hidden="true">
+        <Icon />
+      </span>
+      <div className="callout__content">
+        {title && <p className="callout__title">{title}</p>}
+        <p className="callout__body">{children}</p>
+      </div>
     </div>
   );
 };
@@ -99,91 +148,63 @@ const splitContentAtRatio = (content, ratio = 0.3) => {
 
 // Helper function to create enhanced components for special content patterns
 const createEnhancedComponents = () => {
-  // Function to detect and render info boxes
+  // Function to detect and render info boxes → modern .callout primitives
   const renderInfoBox = (text) => {
     // Pattern: **Info Box:** content
     if (text.startsWith('**Info Box:**')) {
       const content = text.replace('**Info Box:**', '').trim();
-      return (
-        <Alert className="border-blue-200 bg-blue-50 my-4">
-          <Info className="h-4 w-4 text-blue-600" />
-          <AlertTitle>Did You Know?</AlertTitle>
-          <AlertDescription>{content}</AlertDescription>
-        </Alert>
-      );
+      return <Callout variant="note" title="Did You Know?">{content}</Callout>;
     }
-    
+
     // Pattern: **Warning:** content
     if (text.startsWith('**Warning:**')) {
       const content = text.replace('**Warning:**', '').trim();
-      return (
-        <Alert className="border-amber-200 bg-amber-50 my-4">
-          <AlertCircle className="h-4 w-4 text-amber-600" />
-          <AlertTitle>Important</AlertTitle>
-          <AlertDescription>{content}</AlertDescription>
-        </Alert>
-      );
+      return <Callout variant="warning" title="Important">{content}</Callout>;
     }
-    
+
     // Pattern: **Pro Tip:** content
     if (text.startsWith('**Pro Tip:**')) {
       const content = text.replace('**Pro Tip:**', '').trim();
-      return (
-        <Alert className="border-green-200 bg-green-50 my-4">
-          <CheckCircle className="h-4 w-4 text-green-600" />
-          <AlertTitle>Pro Tip</AlertTitle>
-          <AlertDescription>{content}</AlertDescription>
-        </Alert>
-      );
+      return <Callout variant="tip" title="Pro Tip">{content}</Callout>;
     }
-    
+
     // Pattern: **Key Insight:** content
     if (text.startsWith('**Key Insight:**')) {
       const content = text.replace('**Key Insight:**', '').trim();
-      return (
-        <Alert className="border-purple-200 bg-purple-50 my-4">
-          <Lightbulb className="h-4 w-4 text-purple-600" />
-          <AlertTitle>Key Insight</AlertTitle>
-          <AlertDescription>{content}</AlertDescription>
-        </Alert>
-      );
+      return <Callout variant="key" title="Key Insight">{content}</Callout>;
     }
-    
+
     return null;
   };
 
-  // Function to create enhanced product cards
+  // Function to create enhanced product cards → border-first card (brand accents)
   const renderProductCard = (text) => {
     // Pattern: **Product Spotlight: [Product Name]** - details
     const productMatch = text.match(/\*\*Product Spotlight: (.+?)\*\* - (.+)/);
     if (productMatch) {
       const [_, productName, details] = productMatch;
       return (
-        <Card className="hover:shadow-lg transition-shadow cursor-pointer border-green-200 my-6">
-          <CardHeader>
-            <div className="flex justify-between items-start">
-              <CardTitle className="text-green-800">{productName}</CardTitle>
-              <Badge className="bg-green-100 text-green-800">Featured</Badge>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <p className="text-gray-700">{details}</p>
-            <Button variant="outline" size="sm" className="mt-4">
-              See Full Details →
-            </Button>
-          </CardContent>
-        </Card>
+        <div className="not-prose card-raised" style={{ marginBlock: 'var(--space-6)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 'var(--space-4)', marginBottom: 'var(--space-3)' }}>
+            <p className="card-title" style={{ color: 'var(--color-ink)' }}>{productName}</p>
+            <span className="badge badge-brand" style={{ flex: '0 0 auto' }}>Featured</span>
+          </div>
+          <p className="text-soft" style={{ margin: '0 0 var(--space-4)' }}>{details}</p>
+          <CustomLink to="/reviews" className="btn btn-secondary btn-sm" style={{ color: 'var(--color-brand-strong)' }}>
+            See Full Details →
+          </CustomLink>
+        </div>
       );
     }
     return null;
   };
 
-  // Function to render visual separators
+  // Function to render visual separators → quiet brand-green leaf on a hairline
   const renderVisualSeparator = () => (
-    <div className="relative my-12">
-      <Separator className="bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white px-4">
-        <Leaf className="w-6 h-6 text-green-600" />
+    <div className="not-prose" style={{ position: 'relative', marginBlock: 'var(--space-12)' }}>
+      <div style={{ borderTop: '1px solid var(--color-border)' }} />
+      <div style={{ position: 'absolute', left: '50%', top: '50%', transform: 'translate(-50%, -50%)', backgroundColor: 'var(--color-paper)', paddingInline: 'var(--space-4)' }}>
+        <Leaf style={{ width: '1.5rem', height: '1.5rem', color: 'var(--color-brand)' }} aria-hidden="true" />
       </div>
     </div>
   );
@@ -300,6 +321,11 @@ const NewBlogPost = () => {
     const currentPath = window.location.pathname;
     return currentPath.replace('/never-hungover/', '').replace('/newblog/', '');
   };
+
+  // Modern variant: preload the body font once, on mount.
+  useEffect(() => {
+    preloadModernFonts();
+  }, []);
 
   // Listen for URL changes
   useEffect(() => {
@@ -666,16 +692,16 @@ const NewBlogPost = () => {
   // Loading state
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="flex items-center justify-center mb-4">
-            <Loader2 className="w-8 h-8 animate-spin text-green-600 mr-2" />
-            <h1 className="text-2xl font-bold text-gray-900">Never Hungover</h1>
+      <div
+        className="theme-modern"
+        style={{ minHeight: '100vh', backgroundColor: 'var(--color-paper)', color: 'var(--color-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 'var(--space-2)', marginBottom: 'var(--space-4)' }}>
+            <Loader2 className="animate-spin" style={{ width: '2rem', height: '2rem', color: 'var(--color-brand)' }} />
+            <h1 style={{ fontSize: '1.5rem' }}>Never Hungover</h1>
           </div>
-          <p className="text-gray-600 mb-2">Loading post dynamically...</p>
-          <div className="text-sm text-green-600">
-            ⚡ Only loading what you need
-          </div>
+          <p className="text-soft" style={{ margin: 0 }}>Loading post…</p>
         </div>
       </div>
     );
@@ -684,15 +710,18 @@ const NewBlogPost = () => {
   // Error state
   if (loadingError || !post) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">Post Not Found</h1>
-          <p className="text-gray-600 mb-6">
+      <div
+        className="theme-modern"
+        style={{ minHeight: '100vh', backgroundColor: 'var(--color-paper)', color: 'var(--color-ink)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <div style={{ textAlign: 'center', paddingInline: 'var(--space-4)' }}>
+          <h1 style={{ marginBottom: 'var(--space-4)' }}>Post Not Found</h1>
+          <p className="text-soft" style={{ marginBottom: 'var(--space-6)' }}>
             {loadingError || "The blog post you're looking for doesn't exist."}
           </p>
           <button
             onClick={() => handleNavigation('/never-hungover')}
-            className="inline-flex items-center gap-2 bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition-colors"
+            className="btn btn-secondary"
           >
             <ArrowLeft className="w-4 h-4" />
             Back to Never Hungover
@@ -717,53 +746,57 @@ const NewBlogPost = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50">
+    <div
+      className="theme-modern"
+      style={{ minHeight: '100vh', backgroundColor: 'var(--color-paper)', color: 'var(--color-ink)' }}
+    >
       {/* Reading Progress Bar - positioned below header using CSS variable */}
       {isClient && (
         <div
-          className="fixed left-0 w-full h-1 bg-gray-200 z-sticky"
-          style={{ top: 'var(--header-height, 80px)' }}
+          className="fixed left-0 w-full h-1 z-sticky"
+          style={{ top: 'var(--header-height, 80px)', backgroundColor: 'var(--color-border)' }}
         >
           <div
-            className="h-full bg-gradient-to-r from-green-500 to-green-600 transition-all duration-150 ease-out"
-            style={{ width: `${readingProgress}%` }}
+            className="h-full transition-all duration-150 ease-out"
+            style={{ width: `${readingProgress}%`, backgroundColor: 'var(--color-brand)' }}
           />
         </div>
       )}
 
       {/* Header */}
-      <div className="bg-white border-b">
+      <div style={{ backgroundColor: 'var(--color-surface)', borderBottom: '1px solid var(--color-border)' }}>
         <div className="max-w-4xl mx-auto px-4 py-6">
           {/* Breadcrumbs */}
-          <nav className="flex items-center gap-2 text-sm text-gray-500 mb-4">
-            <button 
+          <nav className="flex items-center gap-2 text-sm mb-4" style={{ color: 'var(--color-ink-soft)' }}>
+            <button
               onClick={() => handleNavigation('/')}
-              className="hover:text-green-600 transition-colors"
+              className="transition-colors hover:[color:var(--color-brand-strong)]"
             >
               Home
             </button>
             <ChevronRight className="w-4 h-4" />
-            <button 
+            <button
               onClick={() => handleNavigation('/never-hungover')}
-              className="hover:text-green-600 transition-colors"
+              className="transition-colors hover:[color:var(--color-brand-strong)]"
             >
               Never Hungover
             </button>
             <ChevronRight className="w-4 h-4" />
-            <span className="text-gray-700 truncate">
+            <span className="truncate" style={{ color: 'var(--color-ink)' }}>
               {formatTitle(post.title).mainTitle}
             </span>
           </nav>
 
-          <button 
+          <button
             onClick={() => handleNavigation('/never-hungover')}
-            className="inline-flex items-center gap-2 text-green-600 hover:text-green-700 font-medium transition-colors mb-6"
+            className="btn btn-ghost btn-sm mb-6"
+            style={{ color: 'var(--color-brand-strong)' }}
           >
             <ArrowLeft className="w-4 h-4" />
             Back to Never Hungover
           </button>
-          
-          <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500 mb-4">
+
+          <div className="flex flex-wrap items-center gap-4 text-sm mb-4" style={{ color: 'var(--color-ink-soft)' }}>
             <div className="flex items-center gap-1">
               <Calendar className="w-4 h-4" />
               <span>Last Updated: {formatDate(post.date)}</span>
@@ -782,7 +815,8 @@ const NewBlogPost = () => {
               <button
                 onClick={sharePost}
                 data-track="share"
-                className="flex items-center gap-1 text-green-600 hover:text-green-700 transition-colors"
+                className="flex items-center gap-1 transition-colors hover:[color:var(--color-ink)]"
+                style={{ color: 'var(--color-brand-strong)' }}
               >
                 <Share2 className="w-4 h-4" />
                 Share
@@ -795,13 +829,13 @@ const NewBlogPost = () => {
               const { mainTitle, subtitle } = formatTitle(post.title);
               return (
                 <>
-                  <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-gray-900 leading-tight">
+                  <h1 style={{ marginBottom: subtitle ? 'var(--space-3)' : 0 }}>
                     {mainTitle}
                   </h1>
                   {subtitle && (
-                    <h2 className="text-xl md:text-2xl lg:text-3xl font-medium text-gray-600 mt-3 leading-relaxed">
+                    <p className="lead" style={{ margin: 0 }}>
                       {subtitle}
-                    </h2>
+                    </p>
                   )}
                 </>
               );
@@ -809,7 +843,7 @@ const NewBlogPost = () => {
           </div>
 
           {post.excerpt && (
-            <p className="text-xl text-gray-600 leading-relaxed mb-6">
+            <p className="lead" style={{ marginBottom: 'var(--space-6)' }}>
               {post.excerpt}
             </p>
           )}
@@ -817,10 +851,7 @@ const NewBlogPost = () => {
           {post.tags && post.tags.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {post.tags.map((tag) => (
-                <span 
-                  key={tag}
-                  className="inline-flex items-center gap-1 px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-medium"
-                >
+                <span key={tag} className="chip">
                   <Tag className="w-3 h-3" />
                   {tag}
                 </span>
@@ -835,25 +866,38 @@ const NewBlogPost = () => {
         {isClient && tocItems.length > 0 && (
           <div className="hidden lg:block w-64 flex-shrink-0">
             <div className="sticky" style={{ top: 'calc(var(--header-height, 80px) + 16px)' }}>
-              <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-100">
-                <h3 className="font-bold text-gray-900 mb-4 flex items-center gap-2">
-                  <List className="w-4 h-4 text-green-600" />
+              <div className="card">
+                {/* Navigation-chrome label — deliberately NOT a heading element so
+                    it stays out of the article's semantic outline (h1 → body h2 → h3). */}
+                <p
+                  className="mb-4 flex items-center gap-2"
+                  style={{ fontFamily: 'var(--font-display)', fontSize: '1.125rem', fontWeight: 600, color: 'var(--color-ink)', margin: '0 0 var(--space-4)' }}
+                >
+                  <List className="w-4 h-4" style={{ color: 'var(--color-brand)' }} aria-hidden="true" />
                   Table of Contents
-                </h3>
+                </p>
                 <nav className="space-y-1">
-                  {tocItems.map((item) => (
-                    <button
-                      key={item.id}
-                      onClick={() => scrollToSection(item.id)}
-                      className={`block w-full text-left text-sm py-2 px-3 rounded-lg transition-all duration-150 ${
-                        activeSection === item.id
-                          ? 'bg-green-100 text-green-700 font-medium shadow-sm border-l-2 border-green-500'
-                          : 'text-gray-600 hover:text-green-600 hover:bg-green-50 hover:shadow-sm'
-                      } ${item.level === 3 ? 'ml-4 text-xs' : ''}`}
-                    >
-                      {item.text}
-                    </button>
-                  ))}
+                  {tocItems.map((item) => {
+                    const isActive = activeSection === item.id;
+                    return (
+                      <button
+                        key={item.id}
+                        onClick={() => scrollToSection(item.id)}
+                        className={`block w-full text-left text-sm transition-all duration-150 ${item.level === 3 ? 'ml-4' : ''}`}
+                        style={{
+                          minHeight: '44px',
+                          padding: '0.5rem 0.75rem',
+                          borderRadius: 'var(--radius)',
+                          borderLeft: isActive ? '2px solid var(--color-brand)' : '2px solid transparent',
+                          backgroundColor: isActive ? 'var(--color-brand-soft)' : 'transparent',
+                          color: isActive ? 'var(--color-brand-strong)' : 'var(--color-ink-soft)',
+                          fontWeight: isActive ? 600 : 400,
+                        }}
+                      >
+                        {item.text}
+                      </button>
+                    );
+                  })}
                 </nav>
               </div>
             </div>
@@ -870,17 +914,17 @@ const NewBlogPost = () => {
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.4 }}
                 onClick={() => setShowToc(!showToc)}
-                className="flex items-center gap-2 bg-white px-4 py-3 rounded-lg shadow-md text-gray-700 hover:text-green-600 transition-all duration-200 hover:shadow-lg touch-manipulation min-h-[44px]"
+                className="btn btn-secondary touch-manipulation"
               >
                 <List className="w-4 h-4" />
                 <span>Table of Contents</span>
                 <div className={`transform transition-transform duration-200 ${showToc ? 'rotate-180' : ''}`}>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </div>
               </motion.button>
-              
+
               {/* TOC animation uses grid for GPU-accelerated smooth animation (fixes #97) */}
               <div
                 className="grid transition-all duration-300 ease-in-out"
@@ -890,24 +934,31 @@ const NewBlogPost = () => {
                   className={`overflow-hidden transition-opacity duration-300 ${showToc ? 'opacity-100' : 'opacity-0'}`}
                   style={{ visibility: showToc ? 'visible' : 'hidden' }}
                 >
-                <div className="mt-4 bg-white rounded-lg shadow-lg p-4">
-                  <nav className="space-y-2">
-                    {tocItems.map((item) => (
-                      <button
-                        key={item.id}
-                        onClick={() => {
-                          scrollToSection(item.id);
-                          setShowToc(false);
-                        }}
-                        className={`block w-full text-left text-sm py-2 px-3 rounded transition-all duration-150 ${
-                          activeSection === item.id
-                            ? 'bg-green-100 text-green-700 font-medium shadow-sm'
-                            : 'text-gray-600 hover:text-green-600 hover:bg-green-50'
-                        } ${item.level === 3 ? 'ml-4' : ''}`}
-                      >
-                        {item.text}
-                      </button>
-                    ))}
+                <div className="card mt-4">
+                  <nav className="space-y-1">
+                    {tocItems.map((item) => {
+                      const isActive = activeSection === item.id;
+                      return (
+                        <button
+                          key={item.id}
+                          onClick={() => {
+                            scrollToSection(item.id);
+                            setShowToc(false);
+                          }}
+                          className={`block w-full text-left text-sm transition-all duration-150 ${item.level === 3 ? 'ml-4' : ''}`}
+                          style={{
+                            minHeight: '44px',
+                            padding: '0.5rem 0.75rem',
+                            borderRadius: 'var(--radius)',
+                            backgroundColor: isActive ? 'var(--color-brand-soft)' : 'transparent',
+                            color: isActive ? 'var(--color-brand-strong)' : 'var(--color-ink-soft)',
+                            fontWeight: isActive ? 600 : 400,
+                          }}
+                        >
+                          {item.text}
+                        </button>
+                      );
+                    })}
                   </nav>
                 </div>
               </div>
@@ -916,11 +967,12 @@ const NewBlogPost = () => {
           )}
 
           {/* Article Content */}
-          <motion.article 
+          <motion.article
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
-            className="bg-white rounded-xl shadow-lg overflow-hidden">
+            className="overflow-hidden"
+            style={{ backgroundColor: 'var(--color-surface)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius)' }}>
             {/* Hero Image - aspect-video + width/height attrs prevent CLS (Issue #293) */}
             {post.image && (
               <div className="w-full">
@@ -931,17 +983,40 @@ const NewBlogPost = () => {
                   width={1600}
                   height={900}
                   priority
-                  fetchpriority="high"
+                  fetchPriority="high"
                 />
               </div>
             )}
-            
+
             <div className="p-8 md:p-12">
               {/* Quick Answer callout — positioned in the first ~100 words for AI engine extraction (Perplexity, ChatGPT, Gemini). Issue #292. */}
               {post.quickAnswer && (
-                <div className="max-w-3xl mx-auto mb-8 p-5 bg-blue-50 border-l-4 border-blue-600 rounded-r-lg">
-                  <p className="text-sm font-bold uppercase tracking-wide text-blue-700 mb-1">Quick Answer</p>
-                  <p className="text-base md:text-lg text-gray-900 leading-relaxed m-0">{post.quickAnswer}</p>
+                <div
+                  className="container-prose"
+                  style={{
+                    marginBottom: 'var(--space-8)',
+                    padding: 'var(--space-4) var(--space-6)',
+                    backgroundColor: '#EAF0FE',
+                    borderLeft: '3px solid var(--color-info)',
+                    borderRadius: 'var(--radius)',
+                    border: '1px solid var(--color-border)',
+                  }}
+                >
+                  <p
+                    style={{
+                      margin: '0 0 var(--space-1)',
+                      fontSize: 'var(--text-small)',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      letterSpacing: 'var(--tracking-wide)',
+                      color: 'var(--color-info)',
+                    }}
+                  >
+                    Quick Answer
+                  </p>
+                  <p style={{ margin: 0, fontSize: '1.125rem', lineHeight: 1.6, color: 'var(--color-ink)' }}>
+                    {post.quickAnswer}
+                  </p>
                 </div>
               )}
 
@@ -949,10 +1024,10 @@ const NewBlogPost = () => {
               {keyTakeaways.length > 0 && (
                 <KeyTakeaways takeaways={keyTakeaways} />
               )}
-              
-              {/* Main Content - Constrained Width */}
-              <div className="max-w-3xl mx-auto">
-                <div ref={contentRef} className="prose prose-lg prose-green max-w-none enhanced-typography">
+
+              {/* Main Content — the scoped .article-body typography (Fraunces solid
+                  headings, Inter body ~68ch measure) replaces the Tailwind prose. */}
+              <div ref={contentRef} className="article-body">
                 {(() => {
                   // Shared components config for ReactMarkdown
                   const markdownComponents = {
@@ -965,7 +1040,7 @@ const NewBlogPost = () => {
                       };
                       const text = extractText(children);
                       const id = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-                      return <h1 id={id} className="text-3xl font-bold text-gray-900 mt-8 mb-4 first:mt-0">{children}</h1>;
+                      return <h1 id={id}>{children}</h1>;
                     },
                     h2: ({children}) => {
                       const extractText = (node) => {
@@ -976,7 +1051,7 @@ const NewBlogPost = () => {
                       };
                       const text = extractText(children);
                       const id = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-                      return <h2 id={id} className="text-2xl font-bold text-gray-900 mt-8 mb-4 border-b border-gray-200 pb-2">{children}</h2>;
+                      return <h2 id={id}>{children}</h2>;
                     },
                     h3: ({children}) => {
                       const extractText = (node) => {
@@ -987,12 +1062,7 @@ const NewBlogPost = () => {
                       };
                       const text = extractText(children);
                       const id = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-                      return (
-                        <h3 id={id} className="text-xl font-bold text-gray-900 mt-8 mb-4 relative">
-                          <span className="relative z-10 bg-white pr-4">{children}</span>
-                          <div className="absolute left-0 top-1/2 w-full h-px bg-gradient-to-r from-green-200 to-transparent -translate-y-1/2 -z-0"></div>
-                        </h3>
-                      );
+                      return <h3 id={id}>{children}</h3>;
                     },
                     p: ({children}) => {
                       // Extract text content from children (which might be an array with React elements)
@@ -1009,120 +1079,60 @@ const NewBlogPost = () => {
                       // Check for special patterns only at the start of the paragraph
                       const trimmedText = fullText.trim();
                       
-                      // Check for info box patterns
+                      // Check for info box patterns → modern .callout primitives
                       if (trimmedText.startsWith('Info Box:')) {
                         const content = trimmedText.replace(/^Info Box:\s*/, '');
-                        return (
-                          <Alert className="border-blue-200 bg-blue-50 my-4">
-                            <Info className="h-4 w-4 text-blue-600" />
-                            <AlertTitle>Did You Know?</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="note" title="Did You Know?">{content}</Callout>;
                       }
-                      
+
                       // Check for warning patterns
                       if (trimmedText.startsWith('Warning:')) {
                         const content = trimmedText.replace(/^Warning:\s*/, '');
-                        return (
-                          <Alert className="border-amber-200 bg-amber-50 my-4">
-                            <AlertCircle className="h-4 w-4 text-amber-600" />
-                            <AlertTitle>Important</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="warning" title="Important">{content}</Callout>;
                       }
-                      
+
                       // Check for pro tip patterns
                       if (trimmedText.startsWith('Pro Tip:')) {
                         const content = trimmedText.replace(/^Pro Tip:\s*/, '');
-                        return (
-                          <Alert className="border-green-200 bg-green-50 my-4">
-                            <CheckCircle className="h-4 w-4 text-green-600" />
-                            <AlertTitle>Pro Tip</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="tip" title="Pro Tip">{content}</Callout>;
                       }
-                      
+
                       // Check for key insight patterns
                       if (trimmedText.startsWith('Key Insight:')) {
                         const content = trimmedText.replace(/^Key Insight:\s*/, '');
-                        return (
-                          <Alert className="border-purple-200 bg-purple-50 my-4">
-                            <Lightbulb className="h-4 w-4 text-purple-600" />
-                            <AlertTitle>Key Insight</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="key" title="Key Insight">{content}</Callout>;
                       }
-                      
+
                       // Check for important patterns
                       if (trimmedText.startsWith('Important:')) {
                         const content = trimmedText.replace(/^Important:\s*/, '');
-                        return (
-                          <Alert className="border-red-200 bg-red-50 my-4">
-                            <AlertCircle className="h-4 w-4 text-red-600" />
-                            <AlertTitle>Important</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="warning" title="Important">{content}</Callout>;
                       }
-                      
+
                       // Check for patterns with asterisks (from blockquotes)
                       if (trimmedText.startsWith('**Warning:**')) {
                         const content = trimmedText.replace(/^\*\*Warning:\*\*\s*/, '');
-                        return (
-                          <Alert className="border-amber-200 bg-amber-50 my-4">
-                            <AlertCircle className="h-4 w-4 text-amber-600" />
-                            <AlertTitle>Warning</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="warning" title="Warning">{content}</Callout>;
                       }
-                      
+
                       if (trimmedText.startsWith('**Key Insight:**')) {
                         const content = trimmedText.replace(/^\*\*Key Insight:\*\*\s*/, '');
-                        return (
-                          <Alert className="border-purple-200 bg-purple-50 my-4">
-                            <Lightbulb className="h-4 w-4 text-purple-600" />
-                            <AlertTitle>Key Insight</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="key" title="Key Insight">{content}</Callout>;
                       }
-                      
+
                       if (trimmedText.startsWith('**Pro Tip:**')) {
                         const content = trimmedText.replace(/^\*\*Pro Tip:\*\*\s*/, '');
-                        return (
-                          <Alert className="border-green-200 bg-green-50 my-4">
-                            <CheckCircle className="h-4 w-4 text-green-600" />
-                            <AlertTitle>Pro Tip</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="tip" title="Pro Tip">{content}</Callout>;
                       }
-                      
+
                       if (trimmedText.startsWith('**Emergency Protocol:**')) {
                         const content = trimmedText.replace(/^\*\*Emergency Protocol:\*\*\s*/, '');
-                        return (
-                          <Alert className="border-red-200 bg-red-50 my-4">
-                            <AlertCircle className="h-4 w-4 text-red-600" />
-                            <AlertTitle>Emergency Protocol</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="warning" title="Emergency Protocol">{content}</Callout>;
                       }
-                      
+
                       if (trimmedText.startsWith('**Important Medical Information:**')) {
                         const content = trimmedText.replace(/^\*\*Important Medical Information:\*\*\s*/, '');
-                        return (
-                          <Alert className="border-blue-200 bg-blue-50 my-4">
-                            <Info className="h-4 w-4 text-blue-600" />
-                            <AlertTitle>Important Medical Information</AlertTitle>
-                            <AlertDescription>{content}</AlertDescription>
-                          </Alert>
-                        );
+                        return <Callout variant="note" title="Important Medical Information">{content}</Callout>;
                       }
                       
                       // Skip rendering key takeaways in the main content since we show them at the top
@@ -1130,85 +1140,41 @@ const NewBlogPost = () => {
                         return null;
                       }
                       
-                      // Check for product card patterns
+                      // Check for product card patterns → border-first card
                       if (trimmedText.startsWith('Product Spotlight:')) {
                         const productMatch = trimmedText.match(/^Product Spotlight:\s*([^-]+?)\s*-\s*(.+)/);
                         if (productMatch) {
                           const [_, productName, details] = productMatch;
                           return (
-                            <Card className="hover:shadow-lg transition-shadow cursor-pointer border-green-200 my-6">
-                              <CardHeader>
-                                <div className="flex justify-between items-start">
-                                  <CardTitle className="text-green-800">{productName.trim()}</CardTitle>
-                                  <Badge className="bg-green-100 text-green-800">Featured</Badge>
-                                </div>
-                              </CardHeader>
-                              <CardContent>
-                                <p className="text-gray-700">{details.trim()}</p>
-                                <Button variant="outline" size="sm" className="mt-4">
-                                  See Full Details →
-                                </Button>
-                              </CardContent>
-                            </Card>
+                            <div className="not-prose card-raised" style={{ marginBlock: 'var(--space-6)' }}>
+                              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 'var(--space-4)', marginBottom: 'var(--space-3)' }}>
+                                <p className="card-title" style={{ color: 'var(--color-ink)' }}>{productName.trim()}</p>
+                                <span className="badge badge-brand" style={{ flex: '0 0 auto' }}>Featured</span>
+                              </div>
+                              <p className="text-soft" style={{ margin: '0 0 var(--space-4)' }}>{details.trim()}</p>
+                              <CustomLink to="/reviews" className="btn btn-secondary btn-sm" style={{ color: 'var(--color-brand-strong)' }}>
+                                See Full Details →
+                              </CustomLink>
+                            </div>
                           );
                         }
                       }
-                      
+
                       // Check for separator pattern
                       if (fullText.trim() === '---') {
                         return renderVisualSeparator();
                       }
-                      
-                      // Default paragraph rendering
-                      return <p className="text-gray-700 leading-relaxed mb-4 text-lg">{children}</p>;
+
+                      // Default paragraph rendering — styled by .article-body descendant CSS
+                      return <p>{children}</p>;
                     },
-                    ul: ({children}) => (
-                      <ul className="space-y-3 mb-6 text-lg">
-                        {children}
-                      </ul>
-                    ),
-                    ol: ({children}) => (
-                      <ol className="space-y-3 mb-6 text-lg counter-reset-list">
-                        {children}
-                      </ol>
-                    ),
-                    li: ({children, ...props}) => {
-                      const isOrderedList = props.node?.parentNode?.tagName === 'ol';
-                      const text = typeof children === 'string' ? children : '';
-                      
-                      // Check for special list item patterns
-                      let icon = null;
-                      let specialClass = '';
-                      
-                      if (text.includes('✅') || text.toLowerCase().includes('benefit')) {
-                        icon = <CheckCircle className="w-5 h-5 text-green-600" />;
-                        specialClass = 'bg-green-50 border-l-2 border-green-500 pl-4 -ml-4';
-                      } else if (text.includes('⚠️') || text.toLowerCase().includes('warning')) {
-                        icon = <AlertCircle className="w-5 h-5 text-amber-600" />;
-                        specialClass = 'bg-amber-50 border-l-2 border-amber-500 pl-4 -ml-4';
-                      } else if (text.includes('💡') || text.toLowerCase().includes('tip')) {
-                        icon = <Lightbulb className="w-5 h-5 text-purple-600" />;
-                        specialClass = 'bg-purple-50 border-l-2 border-purple-500 pl-4 -ml-4';
-                      }
-                      
-                      return isOrderedList ? (
-                        <li className={`flex items-start gap-3 leading-relaxed text-gray-700 counter-increment-item ${specialClass}`}>
-                          <span className="flex-shrink-0 w-6 h-6 bg-gradient-to-r from-green-600 to-green-700 text-white text-sm font-bold rounded-full flex items-center justify-center mt-0.5 counter-content">
-                          </span>
-                          <span className="flex-1">{children}</span>
-                        </li>
-                      ) : (
-                        <li className={`flex items-start gap-3 leading-relaxed text-gray-700 ${specialClass}`}>
-                          {icon || <span className="flex-shrink-0 w-2 h-2 bg-gradient-to-r from-green-600 to-green-700 rounded-full mt-3"></span>}
-                          <span className="flex-1">{children}</span>
-                        </li>
-                      );
-                    },
-                    blockquote: ({children}) => (
-                      <blockquote className="border-l-4 border-green-500 pl-6 py-4 my-6 bg-green-50 italic text-gray-700 rounded-r-lg">
-                        {children}
-                      </blockquote>
-                    ),
+                    // Lists + blockquote are styled by .article-body descendant CSS
+                    // (brand-green markers, hanging indent, brand-soft quote). Plain
+                    // elements keep the SEO-visible text/structure untouched.
+                    ul: ({children}) => <ul>{children}</ul>,
+                    ol: ({children}) => <ol>{children}</ol>,
+                    li: ({children}) => <li>{children}</li>,
+                    blockquote: ({children}) => <blockquote>{children}</blockquote>,
                     code: ({node, inline, className, children, ...props}) => {
                       // ReactMarkdown v6+ doesn't always pass inline prop correctly
                       // Check if this is inline code by looking at the parent node
@@ -1235,7 +1201,10 @@ const NewBlogPost = () => {
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <code className="inline bg-gray-100 px-1.5 py-0.5 rounded text-sm font-mono text-gray-800 underline decoration-dotted cursor-help" style={{display: 'inline'}}>
+                                  <code
+                                    className="cursor-help"
+                                    style={{ display: 'inline', textDecoration: 'underline dotted' }}
+                                  >
                                     {children}
                                   </code>
                                 </TooltipTrigger>
@@ -1246,13 +1215,13 @@ const NewBlogPost = () => {
                             </TooltipProvider>
                           );
                         }
-                        
-                        return <code className="inline bg-gray-100 px-1.5 py-0.5 rounded text-sm font-mono text-gray-800" style={{display: 'inline'}} {...props}>{children}</code>;
+
+                        return <code style={{ display: 'inline' }} {...props}>{children}</code>;
                       }
-                      
-                      // Block code
+
+                      // Block code — styled by .article-body pre/code descendant CSS
                       return (
-                        <pre className="bg-gray-100 p-4 rounded-lg overflow-x-auto mb-6">
+                        <pre>
                           <code className={className} {...props}>{children}</code>
                         </pre>
                       );
@@ -1265,7 +1234,7 @@ const NewBlogPost = () => {
                       // hook gets proper placement metadata + Google compliance attrs.
                       const isAffiliate = isExternal && /(?:^|\/\/|\.)(amazon\.[a-z.]{2,6}|amzn\.to)\//i.test(href || '');
 
-                      // Handle hash links (TOC links)
+                      // Handle hash links (TOC links) — internal nav, brand green
                       if (isHashLink && isClient) {
                         return (
                           <span
@@ -1274,7 +1243,8 @@ const NewBlogPost = () => {
                               const targetId = href.slice(1); // Remove the #
                               scrollToSection(targetId);
                             }}
-                            className="text-green-600 hover:text-green-700 underline transition-colors inline-flex items-center gap-1 cursor-pointer"
+                            className="inline-flex items-center gap-1 cursor-pointer underline"
+                            style={{ color: 'var(--color-brand-strong)' }}
                             role="button"
                             tabIndex={0}
                             onKeyDown={(e) => {
@@ -1290,21 +1260,27 @@ const NewBlogPost = () => {
                         );
                       }
 
+                      // Internal article link — brand green (nav), NOT the body blue
                       if (isInternal && isClient) {
                         return (
                           <CustomLink
                             to={href}
-                            className="text-green-600 hover:text-green-700 underline transition-colors inline-flex items-center gap-1"
+                            className="inline-flex items-center gap-1 underline"
+                            style={{ color: 'var(--color-brand-strong)' }}
                           >
                             {children}
                           </CustomLink>
                         );
                       }
 
+                      // External / affiliate link — plain <a>, contract preserved
+                      // byte-for-byte (rel/target/data-placement, NO onClick). Body
+                      // color comes from the .article-body a rule (editorial blue);
+                      // orange is never applied to in-article links.
                       return (
                         <a
                           href={href}
-                          className="text-green-600 hover:text-green-700 underline transition-colors inline-flex items-center gap-1"
+                          className="inline-flex items-center gap-1"
                           target={isExternal ? '_blank' : undefined}
                           rel={isAffiliate ? 'nofollow sponsored noopener noreferrer' : (isExternal ? 'noopener noreferrer' : undefined)}
                           data-placement={isAffiliate ? 'blog_content_inline' : undefined}
@@ -1314,99 +1290,41 @@ const NewBlogPost = () => {
                         </a>
                       );
                     },
-                    strong: ({children}) => {
-                      const text = typeof children === 'string' ? children : '';
-                      const isFormula = text.includes(':') && text.endsWith(':');
-                      
-                      // Check for percentage patterns (e.g., "70% faster")
-                      const percentageMatch = text.match(/^(\d+)%\s+(.+)$/);
-                      if (percentageMatch) {
-                        const [_, percentage, description] = percentageMatch;
-                        return (
-                          <span className="inline-flex items-center gap-2 bg-gradient-to-r from-green-50 to-blue-50 px-3 py-1 rounded-lg border border-green-200">
-                            <strong className="text-2xl font-bold text-green-700">{percentage}%</strong>
-                            <span className="text-gray-700 font-medium">{description}</span>
-                          </span>
-                        );
-                      }
-                      
-                      // Check for key stat patterns (e.g., "300mg" or "$29.99")
-                      const statMatch = text.match(/^([\$]?\d+(?:mg|g|ml|L)?|\$\d+\.\d{2})$/);
-                      if (statMatch) {
-                        return (
-                          <strong className="inline-block text-xl font-bold text-green-700 bg-green-50 px-2 py-1 rounded-md border border-green-200">
-                            {children}
-                          </strong>
-                        );
-                      }
-                      
-                      return isFormula ? (
-                        <strong className="inline-block font-bold gradient-text-green border-b-2 border-green-200 pb-1 mr-1">
-                          {children}
-                        </strong>
-                      ) : (
-                        <strong className="font-bold text-gray-900 bg-green-50 px-1 py-0.5 rounded">
-                          {children}
-                        </strong>
-                      );
-                    },
-                    em: ({children}) => <em className="italic text-gray-700">{children}</em>,
+                    // strong/em styled by .article-body descendant CSS (quiet
+                    // font-weight:600 solid ink — no green pills / gradient text).
+                    strong: ({children}) => <strong>{children}</strong>,
+                    em: ({children}) => <em>{children}</em>,
+                    // Tables wrap in .table-scroll for mobile overflow safety; the
+                    // .article-body table/thead/th/td CSS supplies brand-soft header,
+                    // paper zebra, 1px border + radius.
                     table: ({children}) => (
-                      <div className="overflow-x-auto my-8 rounded-xl shadow-lg border border-gray-200">
-                        <table className="w-full border-collapse bg-white">
-                          {children}
-                        </table>
+                      <div className="table-scroll">
+                        <table>{children}</table>
                       </div>
                     ),
-                    thead: ({children}) => (
-                      <thead className="bg-gradient-to-r from-green-600 to-green-700">
-                        {children}
-                      </thead>
-                    ),
-                    tbody: ({children}) => (
-                      <tbody className="divide-y divide-gray-200">
-                        {children}
-                      </tbody>
-                    ),
-                    tr: ({children, ...props}) => {
-                      const isHeader = props.node?.tagName === 'tr' && props.node?.parentNode?.tagName === 'thead';
-                      return (
-                        <tr className={isHeader ? '' : 'hover:bg-gray-50 transition-colors duration-150'}>
-                          {children}
-                        </tr>
-                      );
-                    },
-                    th: ({children}) => (
-                      <th className="px-6 py-4 text-left text-sm font-bold text-white uppercase tracking-wider border-r border-green-500 last:border-r-0">
-                        {children}
-                      </th>
-                    ),
-                    td: ({children}) => (
-                      <td className="px-6 py-4 text-sm text-gray-700 border-r border-gray-200 last:border-r-0 leading-relaxed">
-                        {children}
-                      </td>
-                    ),
+                    thead: ({children}) => <thead>{children}</thead>,
+                    tbody: ({children}) => <tbody>{children}</tbody>,
+                    tr: ({children}) => <tr>{children}</tr>,
+                    th: ({children}) => <th>{children}</th>,
+                    td: ({children}) => <td>{children}</td>,
                     img: ({src, alt, ...props}) => {
-                      // Use ImageLightbox for blog content images
+                      // Use ImageLightbox for blog content images; rounded + 1px
+                      // border comes from the .article-body img rule on the inner img.
                       return (
-                        <div className="my-8">
-                          <ImageLightbox 
-                            src={src} 
+                        <div style={{ marginBlock: 'var(--space-8)' }}>
+                          <ImageLightbox
+                            src={src}
                             alt={alt}
-                            className="w-full rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300"
+                            className="w-full"
                           />
                         </div>
                       );
                     },
                     hr: () => (
-                      <div className="relative my-12">
-                        <div className="absolute inset-0 flex items-center">
-                          <div className="w-full border-t border-gray-300"></div>
-                        </div>
-                        <div className="relative flex justify-center">
-                          <span className="bg-white px-4">
-                            <Leaf className="w-6 h-6 text-green-600" />
-                          </span>
+                      <div className="not-prose" style={{ position: 'relative', marginBlock: 'var(--space-12)' }}>
+                        <div style={{ borderTop: '1px solid var(--color-border)' }} />
+                        <div style={{ position: 'absolute', left: '50%', top: '50%', transform: 'translate(-50%, -50%)', backgroundColor: 'var(--color-paper)', paddingInline: 'var(--space-4)' }}>
+                          <Leaf style={{ width: '1.5rem', height: '1.5rem', color: 'var(--color-brand)' }} aria-hidden="true" />
                         </div>
                       </div>
                     ),
@@ -1496,59 +1414,85 @@ const NewBlogPost = () => {
                   );
                 })()}
                 </div>
-              </div>
             </div>
           </motion.article>
 
           {/* Related Articles */}
           {relatedPosts.length > 0 && (
-            <div className="mt-8 bg-white rounded-xl shadow-lg p-6">
-              <h3 className="font-bold text-gray-900 mb-6">Related Articles</h3>
+            <div className="card" style={{ marginTop: 'var(--space-8)' }}>
+              <h3
+                style={{ fontFamily: 'var(--font-display)', fontSize: '1.5rem', color: 'var(--color-ink)', marginBottom: 'var(--space-6)' }}
+              >
+                Related Articles
+              </h3>
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {relatedPosts.map((relatedPost) => (
-                  <div
+                  <article
                     key={relatedPost.slug}
-                    className="border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
+                    className="card-raised"
+                    style={{ padding: 0, overflow: 'hidden', height: '100%' }}
                   >
                     <CustomLink
                       to={`/never-hungover/${relatedPost.slug}`}
-                      className="block p-4"
+                      style={{ display: 'flex', flexDirection: 'column', height: '100%', textDecoration: 'none' }}
                     >
                       {relatedPost.image && (
-                        <img
-                          src={relatedPost.image}
-                          alt={relatedPost.title}
-                          className="w-full h-32 object-cover rounded-lg mb-3"
-                          loading="lazy"
-                        />
+                        <div style={{ aspectRatio: '16 / 9', overflow: 'hidden' }}>
+                          <img
+                            src={relatedPost.image}
+                            alt={relatedPost.title}
+                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                            loading="lazy"
+                          />
+                        </div>
                       )}
-                      <h4 className="font-semibold text-gray-900 mb-2 line-clamp-2">
-                        {relatedPost.title}
-                      </h4>
-                      <p className="text-gray-600 text-sm mb-3 line-clamp-2">
-                        {relatedPost.excerpt}
-                      </p>
-                      <div className="flex items-center gap-2 text-xs text-gray-500">
-                        <Clock className="w-3 h-3" />
-                        <span>{relatedPost.readTime} min read</span>
+                      <div style={{ padding: 'var(--space-4)', display: 'flex', flexDirection: 'column', flex: '1 1 auto' }}>
+                        <h4
+                          className="card-title line-clamp-2"
+                          style={{ fontSize: '1.0625rem', color: 'var(--color-ink)', marginBottom: 'var(--space-2)' }}
+                        >
+                          {relatedPost.title}
+                        </h4>
+                        <p
+                          className="text-soft line-clamp-2"
+                          style={{ fontSize: 'var(--text-small)', marginBottom: 'var(--space-3)' }}
+                        >
+                          {relatedPost.excerpt}
+                        </p>
+                        <div
+                          className="cluster"
+                          style={{ gap: 'var(--space-1)', marginTop: 'auto', color: 'var(--color-ink-soft)', fontSize: 'var(--text-eyebrow)' }}
+                        >
+                          <Clock className="w-3 h-3" />
+                          <span>{relatedPost.readTime} min read</span>
+                        </div>
+                        <span
+                          className="cluster"
+                          style={{ gap: 'var(--space-1)', marginTop: 'var(--space-3)', color: 'var(--color-brand-strong)', fontWeight: 600, fontSize: 'var(--text-small)' }}
+                        >
+                          Read
+                          <ChevronRight className="w-4 h-4" />
+                        </span>
                       </div>
                     </CustomLink>
-                  </div>
+                  </article>
                 ))}
               </div>
             </div>
           )}
 
-          {/* Performance Info */}
-          <div className="mt-8 bg-green-50 border border-green-200 rounded-lg p-4 text-sm">
-            <h4 className="font-semibold text-green-800 mb-2">⚡ Dynamically Loaded</h4>
-            <div className="text-green-700 space-y-1">
-              <div>• Post loaded on-demand: {Math.round(JSON.stringify(post).length / 1024)}KB</div>
-              <div>• Related posts preloaded in background</div>
-              <div>• Smart caching active: {getCacheStats().size}/{getCacheStats().maxSize} posts cached</div>
-              <div>• Reading progress and TOC generated client-side</div>
+          {/* Performance Info — dev only, neutral card in production diagnostics off */}
+          {!import.meta.env.PROD && (
+            <div className="card" style={{ marginTop: 'var(--space-8)', fontSize: 'var(--text-small)' }}>
+              <h4 style={{ fontFamily: 'var(--font-display)', color: 'var(--color-ink)', marginBottom: 'var(--space-2)' }}>⚡ Dynamically Loaded</h4>
+              <div className="text-soft" style={{ display: 'grid', gap: '0.25rem' }}>
+                <div>• Post loaded on-demand: {Math.round(JSON.stringify(post).length / 1024)}KB</div>
+                <div>• Related posts preloaded in background</div>
+                <div>• Smart caching active: {getCacheStats().size}/{getCacheStats().maxSize} posts cached</div>
+                <div>• Reading progress and TOC generated client-side</div>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/styles/theme-modern.css
+++ b/src/styles/theme-modern.css
@@ -1692,6 +1692,429 @@
   /* (Footer renders as a light warm-paper surface with .nav-link links — see
      Layout.jsx. The earlier dark-footer `.footer-modern` variant was unused and
      removed to keep this file free of dead CSS.) */
+
+  /* ----------------------------------------------------------------------
+     15. ARTICLE / PROSE + CALLOUTS  (blog POST template — #381 / #384)
+     --------------------------------------------------------------------------
+     The editorial reading system for the ~197-post blog template
+     (src/newblog/components/NewBlogPost.jsx). Replaces the Tailwind Typography
+     `.prose / .prose-lg / .prose-green` body with a scoped, tokenised
+     article-typography sheet so post BODY content reads as a warm-paper
+     editorial page: Fraunces display headings in SOLID ink (never gradient
+     clip-text), Inter body at ~1.125rem / 1.7, a comfortable ~68ch measure,
+     blue in-article links, gold star convention untouched, and the single
+     saturated orange reserved for affiliate/buy CTAs (NEVER emitted by the
+     prose reset — body <a> stay blue; buy CTAs opt into .btn-cta explicitly).
+
+     Contract for consumers (the POST-template restyle, #384):
+       - Wrap the ReactMarkdown output container in .article-body. That is the
+         ONLY class the markdown container needs — every child element (p, h2,
+         h3, ul, ol, li, blockquote, a, strong, img, figure, table, code, pre,
+         hr) is styled by descendant selectors here, so no per-element classes
+         are required and the SEO-critical heading TEXT / hierarchy / anchor IDs
+         / link hrefs are untouched (presentation only).
+       - .prose-modern is an alias of .article-body (identical ruleset) for
+         call-sites that prefer the "prose" name.
+       - In-body callouts (Pro Tip / Warning / Key Insight / Info) migrate to the
+         .callout family below — border-first, AA-contrast, icon + title + body.
+
+     Built ONLY from existing tokens. No new tokens. No new Tailwind z-* utils.
+     ---------------------------------------------------------------------- */
+
+  .article-body,
+  .prose-modern {
+    /* Reading measure + base rhythm. `ch` is relative to the body font, so
+       ~68ch on Inter ≈ a comfortable 60–75-char editorial line. The container
+       centers itself; page layout still controls outer gutters. */
+    max-width: 68ch;
+    margin-inline: auto;
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: 1.125rem;              /* 18px editorial body — up from 17px UI */
+    line-height: 1.7;                 /* relaxed reading leading */
+    font-weight: 400;
+    text-rendering: optimizeLegibility;
+
+    /* ---- Vertical rhythm: children flow with a shared top margin, collapsed
+            at the very start so the body opens flush with its first element. --- */
+    & > * { margin-top: 0; }
+    & > * + * { margin-top: var(--space-6); }
+    & > :first-child { margin-top: 0; }
+    & > :last-child { margin-bottom: 0; }
+
+    /* ---- Paragraphs ---- */
+    p {
+      margin: 0;
+      max-width: none;                /* the container already caps the measure */
+      color: var(--color-ink);
+    }
+
+    /* ---- Headings: Fraunces display, SOLID ink, generous space-before.
+            The article <h1> is rendered ONCE by the page shell (not the body);
+            body headings are h2/h3(/h4). Extra top margin creates section
+            separation without relying on borders. ---- */
+    h2, h3, h4 {
+      font-family: var(--font-display);
+      color: var(--color-ink);        /* solid — never gradient clip-text */
+      font-weight: 600;
+      text-wrap: balance;
+      scroll-margin-top: 6rem;        /* TOC anchor jumps clear the fixed header */
+    }
+    h2 {
+      margin-top: var(--space-12);
+      margin-bottom: var(--space-4);
+      font-size: clamp(1.625rem, 2.5vw, 2rem);
+      line-height: var(--leading-snug);
+      letter-spacing: -0.015em;
+      padding-bottom: var(--space-3);
+      border-bottom: 1px solid var(--color-border);  /* quiet section rule */
+    }
+    h3 {
+      margin-top: var(--space-8);
+      margin-bottom: var(--space-3);
+      font-size: 1.375rem;
+      line-height: var(--leading-snug);
+      letter-spacing: -0.01em;
+    }
+    h4 {
+      margin-top: var(--space-6);
+      margin-bottom: var(--space-2);
+      font-size: 1.125rem;
+      line-height: 1.3;
+      letter-spacing: -0.005em;
+    }
+    /* First heading opens flush (no giant gap under the article header). */
+    & > h2:first-child,
+    & > h3:first-child,
+    & > h4:first-child { margin-top: 0; }
+
+    /* ---- Links: editorial blue with a comfortable underline offset. In-article
+            links are NAVIGATION/reference, never conversion — they stay blue and
+            NEVER take the orange CTA color (buy CTAs opt into .btn-cta). ---- */
+    a {
+      color: var(--color-info);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 0.18em;
+      text-decoration-color: color-mix(in srgb, var(--color-info) 40%, transparent);
+      transition: color var(--transition), text-decoration-color var(--transition);
+    }
+    a:hover {
+      color: var(--color-ink);
+      text-decoration-color: currentColor;
+    }
+
+    /* ---- Emphasis ---- */
+    strong, b { font-weight: 600; color: var(--color-ink); }
+    em, i { font-style: italic; }
+    mark {
+      background: var(--color-brand-soft);
+      color: var(--color-brand-strong);
+      padding: 0.05em 0.25em;
+      border-radius: var(--radius-sm);
+    }
+
+    /* ---- Lists: hanging bullets, tokenised markers, breathing room. ---- */
+    ul, ol {
+      margin: 0;
+      padding-left: 1.5rem;
+      color: var(--color-ink);
+    }
+    ul { list-style: disc; }
+    ol { list-style: decimal; }
+    li { margin: 0 0 var(--space-2); padding-left: 0.25rem; }
+    li::marker { color: var(--color-brand); }        /* brand-green markers */
+    ol > li::marker { color: var(--color-ink-soft); font-weight: 600; }
+    li:last-child { margin-bottom: 0; }
+    /* Nested lists tighten up and inherit spacing. */
+    li > ul, li > ol { margin-top: var(--space-2); margin-bottom: 0; }
+
+    /* ---- Blockquote: brand-green rule + soft surface, NOT a gradient banner. --- */
+    blockquote {
+      margin: 0;
+      padding: var(--space-4) var(--space-6);
+      border-left: 3px solid var(--color-brand);
+      border-radius: 0 var(--radius) var(--radius) 0;
+      background-color: var(--color-brand-soft);
+      color: var(--color-ink);
+      font-style: normal;
+    }
+    blockquote > :first-child { margin-top: 0; }
+    blockquote > :last-child { margin-bottom: 0; }
+    blockquote p { color: var(--color-ink); }
+    blockquote cite {
+      display: block;
+      margin-top: var(--space-2);
+      font-size: var(--text-small);
+      font-style: normal;
+      color: var(--color-ink-soft);
+    }
+
+    /* ---- Images / figures: rounded, bordered, centered with a caption slot. --- */
+    img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      margin-inline: auto;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius);
+    }
+    figure { margin: 0; }
+    figure img { margin-bottom: var(--space-2); }
+    figcaption {
+      font-size: var(--text-small);
+      line-height: 1.5;
+      color: var(--color-ink-soft);
+      text-align: center;
+    }
+
+    /* ---- Horizontal rule ---- */
+    hr {
+      border: 0;
+      border-top: 1px solid var(--color-border);
+      margin-block: var(--space-8);
+    }
+
+    /* ---- Inline code + code blocks: surface bg, mono, no horizontal overflow.
+            <pre> scrolls within its own box so long code never widens the page
+            (mobile 320/375/414 safety). ---- */
+    code, kbd, samp {
+      font-family: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono",
+                   Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+    :not(pre) > code {
+      padding: 0.15em 0.4em;
+      background-color: var(--color-brand-soft);
+      color: var(--color-brand-strong);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+      white-space: break-spaces;      /* wrap long inline tokens, don't overflow */
+      word-break: break-word;
+    }
+    pre {
+      margin: 0;
+      padding: var(--space-4);
+      background-color: var(--color-ink);
+      color: #F4F2EC;                 /* paper-warm ink-on-dark for AA on code */
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius);
+      overflow-x: auto;               /* code scrolls in its box, not the page */
+      -webkit-overflow-scrolling: touch;
+      font-size: var(--text-small);
+      line-height: 1.6;
+      tab-size: 2;
+    }
+    pre code {
+      padding: 0;
+      background: none;
+      border: 0;
+      color: inherit;
+      font-size: inherit;
+      white-space: pre;               /* preserve code formatting */
+      word-break: normal;
+    }
+    kbd {
+      padding: 0.1em 0.4em;
+      background-color: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-bottom-width: 2px;
+      border-radius: var(--radius-sm);
+      font-size: 0.85em;
+      color: var(--color-ink);
+    }
+
+    /* ---- Tables: bordered, zebra-striped, brand-soft header. Wide tables get a
+            horizontal scroll via the .table-scroll wrapper below (mobile safety).
+            The table itself never forces the page wider than the viewport. ---- */
+    table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius);
+      overflow: hidden;               /* clip zebra fills to the rounded corners */
+      font-size: var(--text-small);
+      line-height: 1.5;
+    }
+    th, td {
+      padding: 0.625rem 0.875rem;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--color-border);
+    }
+    thead th {
+      background-color: var(--color-brand-soft);
+      color: var(--color-brand-strong);
+      font-family: var(--font-sans);
+      font-weight: 600;
+      font-size: var(--text-eyebrow);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+    }
+    tbody tr:nth-child(even) td { background-color: var(--color-paper); }  /* zebra */
+    tbody tr:last-child td { border-bottom: 0; }
+    tbody tr:hover td { background-color: var(--color-brand-soft); }
+    /* In-cell links stay blue but drop the underline until hover for scannability. */
+    td a, th a { text-decoration: none; }
+    td a:hover, th a:hover { text-decoration: underline; }
+
+    /* Wide tables/pre/images should scroll in their own box, never the viewport.
+       Wrap a wide <table> in <div class="table-scroll"> to opt in. */
+    .table-scroll {
+      width: 100%;
+      max-width: 100%;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+      scrollbar-color: var(--color-brand) var(--color-brand-soft);
+    }
+    .table-scroll table { min-width: 32rem; }   /* let columns keep width, scroll */
+    .table-scroll::-webkit-scrollbar { height: 8px; }
+    .table-scroll::-webkit-scrollbar-track {
+      background: var(--color-brand-soft);
+      border-radius: var(--radius-pill);
+    }
+    .table-scroll::-webkit-scrollbar-thumb {
+      background: var(--color-brand);
+      border-radius: var(--radius-pill);
+    }
+
+    /* First-child of the body opens flush regardless of element type. */
+    & > p:first-child,
+    & > ul:first-child,
+    & > ol:first-child,
+    & > blockquote:first-child { margin-top: 0; }
+  }
+
+  /* ----------------------------------------------------------------------
+     15b. CALLOUT FAMILY  (in-article notes / tips / warnings / key insights)
+     --------------------------------------------------------------------------
+     Border-first note primitives for the post body. Each is a coloured hairline
+     card with a leading icon slot, a bold title, and a body — the modern
+     replacement for the shadcn <Alert> / green-gradient boxes the control
+     template used. AA-contrast text on soft tint fills.
+
+     Structure (consumer markup — #384):
+       <div class="callout callout--tip" role="note">
+         <span class="callout__icon" aria-hidden="true"><!-- lucide icon --></span>
+         <div class="callout__content">
+           <p class="callout__title">Pro Tip</p>
+           <p class="callout__body">…</p>
+         </div>
+       </div>
+
+     Variants (accent + soft fill):
+       .callout--note     info-blue    (default / neutral reference)
+       .callout--tip      brand-green  (pro tips, do-this guidance)
+       .callout--warning  warm-amber   (cautions, medical warnings)
+       .callout--key      neutral ink  (key insight / takeaway)
+
+     `--_c-accent` / `--_c-fill` / `--_c-ink` are per-instance custom props each
+     variant sets, so the base .callout ruleset stays variant-agnostic.
+     ---------------------------------------------------------------------- */
+
+  .callout {
+    --_c-accent: var(--color-info);
+    --_c-fill:   #EAF0FE;                 /* info-blue soft (matches .badge-info) */
+    --_c-ink:    var(--color-ink);
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    gap: var(--space-3);
+    margin-block: var(--space-6);
+    padding: var(--space-4) var(--space-6);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--_c-accent);
+    border-radius: var(--radius);
+    background-color: var(--_c-fill);
+    color: var(--_c-ink);
+    font-family: var(--font-sans);
+    font-size: var(--text-body);
+    line-height: 1.6;
+  }
+
+  /* Icon slot — a small rounded chip carrying the variant accent. */
+  .callout__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    margin-top: 0.05rem;                  /* optical-center on the title line */
+    border-radius: var(--radius-pill);
+    background-color: color-mix(in srgb, var(--_c-accent) 14%, transparent);
+    color: var(--_c-accent);
+    flex: 0 0 auto;
+  }
+  .callout__icon svg,
+  .callout__icon [data-lucide] { width: 1rem; height: 1rem; }
+
+  .callout__content { min-width: 0; }     /* let long words/links wrap, no overflow */
+
+  .callout__title {
+    margin: 0 0 var(--space-1);
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: var(--text-small);
+    line-height: 1.3;
+    letter-spacing: 0.01em;
+    color: var(--_c-accent);
+  }
+
+  .callout__body {
+    margin: 0;
+    max-width: none;
+    color: var(--color-ink);
+    font-size: var(--text-body);
+    line-height: 1.6;
+  }
+  .callout__body > :first-child { margin-top: 0; }
+  .callout__body > :last-child { margin-bottom: 0; }
+  /* Links inside callouts inherit the variant accent (stays blue/green/amber
+     with the note) rather than the generic body link blue. */
+  .callout__body a {
+    color: var(--_c-accent);
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+  }
+  .callout__body a:hover { color: var(--color-ink); }
+
+  /* ---- Variants: set the accent + soft fill; body ink stays --color-ink. ---- */
+
+  /* NOTE / info — blue (reference, "did you know") — the default. */
+  .callout--note {
+    --_c-accent: var(--color-info);
+    --_c-fill:   #EAF0FE;
+  }
+  /* TIP — brand green ("Pro Tip", do-this guidance). */
+  .callout--tip {
+    --_c-accent: var(--color-brand-strong);
+    --_c-fill:   var(--color-brand-soft);
+  }
+  /* WARNING — warm amber (cautions, medical warnings). Amber ≠ CTA orange:
+     #B45309 text-weight accent + a soft #FDF4E6 fill keep it distinct from the
+     protected conversion orange while still reading as "caution". */
+  .callout--warning {
+    --_c-accent: #B45309;                 /* amber-700 — AA on the soft fill */
+    --_c-fill:   #FDF4E6;                 /* warm amber wash */
+  }
+  /* KEY / insight — neutral ink (a quiet, authoritative takeaway box). */
+  .callout--key {
+    --_c-accent: var(--color-ink);
+    --_c-fill:   color-mix(in srgb, var(--color-ink) 5%, var(--color-surface));
+    --_c-ink:    var(--color-ink);
+  }
+  .callout--key .callout__title { color: var(--color-ink); }
+  .callout--key .callout__body a { color: var(--color-info); }
+
+  /* When a callout lives INSIDE the article body, neutralise the prose reset's
+     child-margin rhythm so its internal <p>/<ul> keep the tight callout spacing. */
+  .article-body .callout,
+  .prose-modern .callout { max-width: none; }
+  .article-body .callout > *,
+  .prose-modern .callout > * { margin-top: 0; }
 }
 
 /* --------------------------------------------------------------------------

--- a/tests/layout-invariants.spec.js
+++ b/tests/layout-invariants.spec.js
@@ -49,7 +49,7 @@ const EXP = 'exp_site-modern-v1=modern';
 // is where the comparison table is widest and, in the laptop band, requires
 // horizontal scrolling — the real defect the old process missed. Guarding it
 // permanently means the table can never silently outgrow the laptop viewport again.
-const ROUTES = (process.env.INVARIANT_ROUTES || '/;/reviews;/guide;/research;/compare;/compare?products=1,2,3,4;/never-hungover;/about;/dhm-dosage-calculator')
+const ROUTES = (process.env.INVARIANT_ROUTES || '/;/reviews;/guide;/research;/compare;/compare?products=1,2,3,4;/never-hungover;/never-hungover/when-to-take-dhm-timing-guide-2025;/about;/dhm-dosage-calculator')
   .split(';')
   .map((s) => s.trim())
   .filter(Boolean);

--- a/tests/restyle-blog.spec.js
+++ b/tests/restyle-blog.spec.js
@@ -1,0 +1,550 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * CONTRACT spec for the BLOG POST TEMPLATE restyle to the modern design system.
+ *
+ *   Template component: src/newblog/components/NewBlogPost.jsx
+ *   Renders: ALL ~197 posts at /never-hungover/<slug>
+ *   Sample URL under test: /never-hungover/when-to-take-dhm-timing-guide-2025
+ *
+ * This is the site's HIGHEST-TRAFFIC ORGANIC SURFACE — a single component
+ * powers every post, so an SEO regression here degrades the whole site. Unlike
+ * the hub/reviews/home pages, the post template has NO ".modern" A/B arm: it is
+ * a DIRECT, in-place restyle. The spec therefore visits the PLAIN post URL (no
+ * ?exp_site-modern-v1=modern override) and asserts the restyle is present for
+ * every visitor.
+ *
+ * Modern language reference:
+ *   - src/styles/theme-modern.css        (tokens + scoped .theme-modern classes)
+ *   - src/newblog/pages/NewBlogListing.modern.jsx (the modern blog HUB — mirror
+ *     its `import '../../styles/theme-modern.css'`, its <div className="theme-modern">
+ *     wrapper, and preloadModernFonts() on mount)
+ *   - src/pages/Reviews.modern.jsx
+ *
+ * Two axes of assertions:
+ *   STYLE (must FLIP once restyled):
+ *     - the article shell is inside a .theme-modern subtree (self or ancestor)
+ *     - the post <h1> AND the in-article <h2>s render in Fraunces (display face)
+ *     - NO gradient clip-text (transparent-filled + background-clip:text) anywhere
+ *     - NO rainbow / two-hue gradient BACKGROUND on the page shell or article
+ *     - the reserved conversion-orange appears ONLY on in-post affiliate/buy CTAs;
+ *       internal nav/links (TOC, /reviews, /never-hungover, breadcrumbs) are NOT
+ *       orange
+ *
+ *   SEO PRESERVED (must STAY green — the byte-for-byte contract):
+ *     - exactly one <h1>
+ *     - at least one parseable JSON-LD script[type="application/ld+json"] whose
+ *       @type graph includes Article OR BlogPosting
+ *     - a non-empty <title> and a meta[name="description"] exist
+ *     - heading order has no skipped levels (single h1, no h2→h4 jumps)
+ *
+ *   BEHAVIOR:
+ *     - IF any in-article affiliate <a> exists, it carries rel*="nofollow" +
+ *       rel*="sponsored" + target="_blank" + a data-* attribute and NO inline
+ *       onClick (the global useAffiliateTracking listener fires the event —
+ *       a per-anchor onClick would double-count). (This sample post happens to
+ *       have zero body affiliate links, so the assertion is conditional; it
+ *       still guards every OTHER post that flows through the same template.)
+ *     - the table-of-contents / in-page anchor links resolve to REAL element ids
+ *     - related-posts render
+ *     - zero console / page errors (third-party pixel noise filtered)
+ *
+ *   A11Y / RESPONSIVE:
+ *     - no horizontal overflow at 375px (watch wide article tables / images)
+ *     - TOC + CTA tap targets are >=44px on mobile
+ *
+ * All visual assertions use getComputedStyle (NOT class-name matching) so the
+ * spec survives a Tailwind-utility → theme-modern refactor.
+ */
+
+const POST_URL = '/never-hungover/when-to-take-dhm-timing-guide-2025';
+const MOBILE = { width: 375, height: 812 };
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors tests/restyle-secondary.spec.js house style)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve any CSS color string (rgb/hex/oklch/…) to sRGB using the browser's own
+ * parser via a 1×1 canvas — Tailwind v4 emits oklch(…), which a naive regex
+ * mis-parses. Runs page-side.
+ */
+async function toSRGB(page, color) {
+  return page.evaluate((c) => {
+    const cv = document.createElement('canvas');
+    cv.width = cv.height = 1;
+    const ctx = cv.getContext('2d');
+    ctx.fillStyle = '#000';
+    ctx.fillStyle = c;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+    return { r, g, b, a };
+  }, color);
+}
+
+/** True if a resolved sRGB color reads as the reserved conversion-orange. */
+function isOrangeRGB({ r, g, b, a }) {
+  if (a === 0) return false;
+  // #F97316 (249,115,22) / #EA580C (234,88,12): strong red, mid green, low blue.
+  return r > 200 && g > 70 && g < 160 && b < 70;
+}
+
+/** Shared error-collector wiring (matches the reference specs). */
+function wireErrors(page, errors) {
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    // Third-party analytics/pixel noise (PostHog/GA/Clarity) fails in local dev
+    // with placeholder IDs; filter the generic resource error only.
+    if (/Failed to load resource/i.test(text)) return;
+    errors.push(`console: ${text}`);
+  });
+  page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+  // App-origin 4xx/5xx (a missing chunk/font) DO fail; third-party domains don't.
+  page.on('response', (resp) => {
+    if (resp.status() >= 400 && /localhost|127\.0\.0\.1/.test(resp.url())) {
+      errors.push(`http ${resp.status()}: ${resp.url()}`);
+    }
+  });
+}
+
+/** Wait until the async-loaded post has actually rendered its article + body. */
+async function waitForPost(page) {
+  // The article body is populated via a dynamic import + markdown render.
+  await page.locator('h1').first().waitFor({ state: 'visible', timeout: 15000 });
+  // A real post h2 (inside the article body) confirms markdown finished.
+  await page.locator('article h2, main h2').first().waitFor({ state: 'visible', timeout: 15000 });
+  await page.waitForTimeout(600); // let the TOC MutationObserver assign ids
+}
+
+/** Assert the article shell (its H1) is inside a .theme-modern subtree. */
+async function expectThemeModernScope(page) {
+  const inScope = await page.locator('h1').first().evaluate((el) => {
+    let node = /** @type {Element|null} */ (el);
+    while (node) {
+      if (node.classList && node.classList.contains('theme-modern')) return true;
+      node = node.parentElement;
+    }
+    return false;
+  });
+  expect(
+    inScope,
+    'Expected the post H1 to be inside a .theme-modern subtree (self or ancestor). ' +
+      'Wrap the article shell in <div className="theme-modern"> and import theme-modern.css.'
+  ).toBe(true);
+}
+
+/** Assert an element renders in Fraunces (modern display face). */
+async function expectFraunces(locator, label) {
+  const font = await locator.evaluate((el) => getComputedStyle(el).fontFamily);
+  expect(
+    /fraunces/i.test(font),
+    `${label} font-family "${font}" must include Fraunces (modern display face).`
+  ).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// STYLE + SEO + BEHAVIOR — desktop (chromium)
+// ---------------------------------------------------------------------------
+test.describe('Blog post template — modern restyle contract', () => {
+  /** @type {string[]} */
+  let errors;
+
+  test.beforeEach(async ({ page }) => {
+    errors = [];
+    wireErrors(page, errors);
+    await page.goto(POST_URL);
+    await page.waitForLoadState('domcontentloaded');
+    await waitForPost(page);
+  });
+
+  // ---- STYLE ----
+
+  test('article shell is wrapped in .theme-modern', async ({ page }) => {
+    await expectThemeModernScope(page);
+  });
+
+  test('the post H1 renders in Fraunces', async ({ page }) => {
+    const h1 = page.getByRole('heading', { level: 1 }).first();
+    await expect(h1, 'a single visible H1 must exist').toBeVisible();
+    await expectFraunces(h1, 'Post H1');
+  });
+
+  test('in-article H2s render in Fraunces', async ({ page }) => {
+    // The body markdown emits multiple <h2> section headings — they are the
+    // biggest typographic tell of the restyle (editorial Fraunces vs sans).
+    const h2s = page.locator('article h2, main h2');
+    const count = await h2s.count();
+    expect(count, 'the post body must render at least one <h2>').toBeGreaterThan(0);
+    // Check the first few visible h2s.
+    const checkN = Math.min(count, 3);
+    for (let i = 0; i < checkN; i++) {
+      const h2 = h2s.nth(i);
+      if (!(await h2.isVisible())) continue;
+      await expectFraunces(h2, `Post H2 #${i}`);
+    }
+  });
+
+  test('no gradient clip-text anywhere on the post', async ({ page }) => {
+    const offenders = await page.locator('body *').evaluateAll((els) =>
+      els
+        .filter((el) => {
+          const cs = getComputedStyle(el);
+          const clip =
+            cs.getPropertyValue('background-clip') ||
+            cs.getPropertyValue('-webkit-background-clip');
+          const fill = cs.getPropertyValue('-webkit-text-fill-color') || cs.color;
+          return /text/i.test(clip) && /transparent|rgba\(0, 0, 0, 0\)/i.test(fill);
+        })
+        .map((el) => `${el.tagName.toLowerCase()}.${el.className}`)
+        .slice(0, 8)
+    );
+    expect(
+      offenders,
+      `No gradient clip-text allowed (solid ink headings only). Offenders: ${offenders.join(' | ')}`
+    ).toEqual([]);
+  });
+
+  test('no rainbow / two-hue gradient background on the page shell or article', async ({
+    page,
+  }) => {
+    // The control shell uses bg-gradient-to-br from-green-50 to-blue-50 (rainbow
+    // wash) and the article uses shadow-xl/rounded-xl white cards. After the
+    // restyle the shell must read as warm paper (a solid --color-paper or an
+    // approved single-hue paper→brand-soft wash), NEVER a saturated green→blue
+    // gradient. We flag any element with a multi-stop linear-gradient whose stops
+    // span clearly different hues (a green + a blue/purple).
+    const offenders = await page.evaluate(() => {
+      function hueOf(r, g, b) {
+        r /= 255; g /= 255; b /= 255;
+        const max = Math.max(r, g, b), min = Math.min(r, g, b);
+        const d = max - min;
+        if (d < 0.04) return -1; // near-grey, no meaningful hue
+        let h;
+        if (max === r) h = ((g - b) / d) % 6;
+        else if (max === g) h = (b - r) / d + 2;
+        else h = (r - g) / d + 4;
+        h = Math.round(h * 60);
+        if (h < 0) h += 360;
+        return h;
+      }
+      const bad = [];
+      const nodes = Array.from(document.querySelectorAll('main *, [class*="min-h-screen"], article'));
+      for (const el of nodes) {
+        const bg = getComputedStyle(el).backgroundImage;
+        if (!bg || bg === 'none' || !/gradient/i.test(bg)) continue;
+        // Pull rgb triples out of the gradient string.
+        const rgbs = [...bg.matchAll(/rgba?\(([^)]+)\)/g)].map((m) =>
+          m[1].split(',').slice(0, 3).map((n) => parseFloat(n))
+        );
+        const hues = rgbs
+          .map(([r, g, b]) => hueOf(r, g, b))
+          .filter((h) => h >= 0);
+        if (hues.length < 2) continue;
+        // green ≈ 90–170, blue/purple ≈ 200–290. A gradient that spans from a
+        // green-ish stop to a blue/purple-ish stop is the banned rainbow wash.
+        const hasGreen = hues.some((h) => h >= 80 && h <= 175);
+        const hasBlue = hues.some((h) => h >= 195 && h <= 300);
+        if (hasGreen && hasBlue) {
+          bad.push(`${el.tagName.toLowerCase()}.${el.className}: ${bg.slice(0, 90)}`);
+        }
+      }
+      return bad.slice(0, 6);
+    });
+    expect(
+      offenders,
+      `Banned rainbow (green→blue) gradient background found on:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  test('reserved conversion-orange appears ONLY on affiliate/buy CTAs (internal links are NOT orange)', async ({
+    page,
+  }) => {
+    // Walk every anchor. An affiliate/buy CTA = an external Amazon link (amzn.to
+    // / amazon.<tld>) OR an <a> explicitly tagged as an affiliate CTA
+    // (rel~=sponsored). Those MAY be orange. EVERY OTHER anchor — internal nav,
+    // TOC (#), /reviews, /never-hungover, breadcrumbs — must NOT be orange.
+    const offenders = await page.evaluate(() => {
+      function reads(el, prop) {
+        const c = getComputedStyle(el)[prop];
+        const m = (c.match(/[\d.]+/g) || []).map(Number);
+        if (m.length < 3) return null;
+        const [r, g, b, a = 1] = m;
+        if (a === 0) return null;
+        return r > 200 && g > 70 && g < 160 && b < 70 ? c : null;
+      }
+      const bad = [];
+      for (const el of document.querySelectorAll('a')) {
+        const href = (el.getAttribute('href') || '').toLowerCase();
+        const rel = (el.getAttribute('rel') || '').toLowerCase();
+        const isAffiliate =
+          /amzn\.to|amazon\./.test(href) || rel.includes('sponsored');
+        if (isAffiliate) continue; // orange is ALLOWED here
+        const bg = reads(el, 'backgroundColor');
+        const fg = reads(el, 'color');
+        if (bg || fg) {
+          bad.push(
+            `<a href="${href.slice(0, 40)}">: ${bg ? 'bg=' + bg : ''} ${fg ? 'fg=' + fg : ''} [${(el.textContent || '').trim().slice(0, 30)}]`
+          );
+        }
+      }
+      return bad;
+    });
+    expect(
+      offenders,
+      `Reserved conversion-orange found on NON-affiliate link(s) (internal nav/TOC/links must be brand green or ink, never orange):\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  // ---- SEO PRESERVED ----
+
+  test('exactly one <h1>', async ({ page }) => {
+    const h1Count = await page.locator('h1').count();
+    expect(h1Count, `Expected exactly one <h1>, found ${h1Count}.`).toBe(1);
+  });
+
+  test('at least one parseable Article/BlogPosting JSON-LD block', async ({ page }) => {
+    const blocks = await page.locator('script[type="application/ld+json"]').allTextContents();
+    expect(
+      blocks.length,
+      'At least one JSON-LD script[type="application/ld+json"] must be present.'
+    ).toBeGreaterThan(0);
+
+    /** collect every @type across every graph, tolerating parse of each block */
+    const types = new Set();
+    let parsedAny = false;
+    for (const raw of blocks) {
+      let data;
+      try {
+        data = JSON.parse(raw);
+        parsedAny = true;
+      } catch {
+        continue; // a single malformed block shouldn't crash the assertion
+      }
+      const visit = (node) => {
+        if (!node || typeof node !== 'object') return;
+        if (Array.isArray(node)) return node.forEach(visit);
+        if (node['@type']) {
+          const t = node['@type'];
+          (Array.isArray(t) ? t : [t]).forEach((x) => types.add(String(x)));
+        }
+        if (node['@graph']) visit(node['@graph']);
+        for (const k of Object.keys(node)) {
+          if (k !== '@type' && k !== '@graph' && typeof node[k] === 'object') visit(node[k]);
+        }
+      };
+      visit(data);
+    }
+    expect(parsedAny, 'At least one JSON-LD block must parse as valid JSON.').toBe(true);
+    const hasArticle = types.has('Article') || types.has('BlogPosting');
+    expect(
+      hasArticle,
+      `JSON-LD must include an Article/BlogPosting @type. Found types: [${[...types].join(', ')}]`
+    ).toBe(true);
+  });
+
+  test('a non-empty <title> and meta description exist', async ({ page }) => {
+    const title = await page.title();
+    expect(title.trim().length, 'document <title> must be non-empty').toBeGreaterThan(0);
+    expect(
+      title,
+      'the post title text must be preserved in the <title>'
+    ).toContain('When to Take DHM');
+
+    const desc = await page.locator('meta[name="description"]').first().getAttribute('content');
+    expect((desc || '').trim().length, 'meta[name="description"] must be non-empty').toBeGreaterThan(0);
+  });
+
+  test('heading order has no skipped levels', async ({ page }) => {
+    const levels = await page
+      .locator('h1, h2, h3, h4, h5, h6')
+      .evaluateAll((els) => els.map((e) => Number(e.tagName.slice(1))));
+    expect(levels.length, 'the post must render headings').toBeGreaterThan(1);
+    expect(levels[0], 'the first heading on the page must be the <h1>').toBe(1);
+    let prev = levels[0];
+    const jumps = [];
+    for (const lvl of levels) {
+      if (lvl > prev + 1) jumps.push(`${prev}→${lvl}`);
+      prev = lvl;
+    }
+    expect(
+      jumps,
+      `Heading order must not skip levels (e.g. h2→h4). Skips: ${jumps.join(', ')}`
+    ).toEqual([]);
+  });
+
+  // ---- BEHAVIOR ----
+
+  test('in-article affiliate <a> (if any) carries the compliance + tracking contract with NO onClick', async ({
+    page,
+  }) => {
+    // This template auto-injects internal /reviews CTAs and renders body markdown
+    // links; SOME posts contain Amazon affiliate links in the body. Wherever one
+    // exists it MUST be a plain <a> with Google-compliance rel + target + a
+    // data-* hook and NO inline onclick (the global listener fires the event).
+    const ctas = page.locator(
+      'article a[href*="amzn.to"], article a[href*="amazon."], main a[href*="amzn.to"], main a[href*="amazon."]'
+    );
+    const count = await ctas.count();
+    // Conditional: the sample post has zero body affiliate links, so we don't
+    // REQUIRE existence — but we DO enforce the contract on any that appear.
+    for (let i = 0; i < count; i++) {
+      const a = ctas.nth(i);
+      const [rel, target, onclick, dataPlacement, dataTrack] = await Promise.all([
+        a.getAttribute('rel'),
+        a.getAttribute('target'),
+        a.getAttribute('onclick'),
+        a.getAttribute('data-placement'),
+        a.getAttribute('data-track'),
+      ]);
+      const relLower = (rel || '').toLowerCase();
+      expect(relLower, `affiliate #${i}: rel="${rel}" must contain "nofollow"`).toContain('nofollow');
+      expect(relLower, `affiliate #${i}: rel="${rel}" must contain "sponsored"`).toContain('sponsored');
+      expect(target, `affiliate #${i}: target must be "_blank"`).toBe('_blank');
+      expect(
+        onclick,
+        `affiliate #${i}: must NOT have an inline onclick (global listener handles tracking)`
+      ).toBeNull();
+      expect(
+        (dataPlacement || dataTrack || '').length,
+        `affiliate #${i}: must carry a data-* hook (data-placement / data-track) for tracking`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  test('table-of-contents / in-page anchor links resolve to real element ids', async ({
+    page,
+  }) => {
+    // The desktop TOC renders as a sidebar nav of <button>s that scroll to
+    // generated heading ids; on mobile it collapses behind a toggle button.
+    // in-body hash anchors (if present) also target real ids. Assert that every
+    // TOC target corresponds to a heading id that exists in the DOM.
+    // 1) A Table of Contents affordance must render (desktop sidebar OR mobile
+    //    toggle — whichever is visible for the current viewport).
+    const tocAny = page.getByText('Table of Contents', { exact: false });
+    // The desktop sidebar copy is hidden on mobile and vice-versa; require that
+    // AT LEAST ONE Table-of-Contents element is visible for this viewport.
+    const tocCount = await tocAny.count();
+    let anyTocVisible = false;
+    for (let i = 0; i < tocCount; i++) {
+      if (await tocAny.nth(i).isVisible()) { anyTocVisible = true; break; }
+    }
+    expect(
+      anyTocVisible,
+      'a Table of Contents affordance (desktop sidebar or mobile toggle) must render for a multi-heading post'
+    ).toBe(true);
+
+    // 2) Every heading the TOC is built from must carry a resolvable id.
+    const headingIds = await page
+      .locator('article h2, article h3, main h2, main h3')
+      .evaluateAll((els) => els.map((e) => e.id).filter(Boolean));
+    expect(
+      headingIds.length,
+      'Article h2/h3 headings must each receive a stable id (TOC anchor target).'
+    ).toBeGreaterThan(0);
+
+    // 3) Each id must resolve to exactly one element (no dangling anchors).
+    const dangling = await page.evaluate((ids) => {
+      return ids.filter((id) => !document.getElementById(id));
+    }, headingIds);
+    expect(
+      dangling,
+      `Every TOC/anchor id must resolve to a real element. Dangling: ${dangling.join(', ')}`
+    ).toEqual([]);
+
+    // 4) Any in-body hash anchor (<a href="#...">) must point at a real id too.
+    const badHashes = await page.evaluate(() => {
+      const bad = [];
+      for (const a of document.querySelectorAll('article a[href^="#"], main a[href^="#"]')) {
+        const id = a.getAttribute('href').slice(1);
+        if (id && !document.getElementById(id)) bad.push(id);
+      }
+      return bad;
+    });
+    expect(
+      badHashes,
+      `In-body hash anchors must resolve to real ids. Broken: ${badHashes.join(', ')}`
+    ).toEqual([]);
+  });
+
+  test('related posts render', async ({ page }) => {
+    const relHeading = page.getByRole('heading', { name: /related articles/i }).first();
+    await expect(relHeading, 'a "Related Articles" section must render').toBeVisible();
+    // The related section links to other /never-hungover/<slug> posts.
+    const relLinks = page.locator('a[href^="/never-hungover/"]');
+    const count = await relLinks.count();
+    expect(count, 'related posts must render internal /never-hungover/<slug> links').toBeGreaterThan(0);
+  });
+
+  test('no console / page errors', async ({ page }) => {
+    // Currently RED because the control template renders the hero <Picture> with
+    // a lowercase `fetchpriority` attribute, which React rejects
+    // ("Invalid DOM property `fetchpriority`. Did you mean `fetchPriority`?").
+    // The restyle touches that hero markup — fix the casing to `fetchPriority`
+    // (JSX) so the console stays clean. Third-party pixel noise is already
+    // filtered in wireErrors().
+    expect(errors, `Page produced errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A11Y / RESPONSIVE — mobile viewport (375px)
+// ---------------------------------------------------------------------------
+test.describe('Blog post template — mobile a11y / responsive', () => {
+  test.use({ viewport: MOBILE });
+
+  /** @type {string[]} */
+  let errors;
+
+  test.beforeEach(async ({ page }) => {
+    errors = [];
+    wireErrors(page, errors);
+    await page.goto(POST_URL);
+    await page.waitForLoadState('domcontentloaded');
+    await waitForPost(page);
+  });
+
+  test('no horizontal overflow at 375px (watch wide tables/images)', async ({ page }) => {
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(
+      overflow.scrollWidth,
+      `Horizontal overflow at 375px: scrollWidth=${overflow.scrollWidth} > clientWidth=${overflow.clientWidth} + 4`
+    ).toBeLessThanOrEqual(overflow.clientWidth + 4);
+  });
+
+  test('the mobile Table-of-Contents toggle is a >=44px tap target', async ({ page }) => {
+    // On mobile the TOC collapses behind a toggle control. It must meet the 44px
+    // minimum touch target of the modern system.
+    const toggle = page.getByRole('button', { name: /table of contents/i }).first();
+    await expect(toggle, 'a mobile Table of Contents toggle must render').toBeVisible();
+    const box = await toggle.boundingBox();
+    expect(box, 'TOC toggle must have a layout box').not.toBeNull();
+    expect(
+      box.height,
+      `mobile TOC toggle height ${box?.height}px must be >= 44px`
+    ).toBeGreaterThanOrEqual(44);
+  });
+
+  test('the injected /reviews CTA link is a >=44px tap target', async ({ page }) => {
+    // The template auto-injects an internal /reviews CTA ("See our top-rated
+    // picks"). As an internal nav CTA it must be brand green (not orange) and a
+    // comfortable mobile tap target. Scope to the article-body CTA via its stable
+    // data-element-name hook so we don't match the header nav's /reviews link.
+    const cta = page
+      .locator('a[data-element-name="blog_template_reviews_cta"], article a[href="/reviews"], main a[href="/reviews"]')
+      .first();
+    if ((await cta.count()) === 0) test.skip(true, 'no /reviews CTA on this post');
+    await cta.scrollIntoViewIfNeeded();
+    await expect(cta).toBeVisible();
+    const box = await cta.boundingBox();
+    expect(box, '/reviews CTA must have a layout box').not.toBeNull();
+    expect(
+      box.height,
+      `/reviews CTA height ${box?.height}px must be >= 44px`
+    ).toBeGreaterThanOrEqual(44);
+  });
+});


### PR DESCRIPTION
Restyles **`NewBlogPost.jsx`** — which renders **all ~197 blog posts** (the highest organic surface) — to the modern design system, and adds the **article-prose + callout primitives** (finishing #381). Component-only; **SEO byte-identical**.

## What
- **`theme-modern.css`** — ARTICLE/PROSE + CALLOUTS block: `.article-body`/`.prose-modern` (Fraunces h2/h3, Inter ~68ch measure, styled lists/blockquote/links/img/table/code), `.table-scroll` (wide tables/pre scroll safely on mobile), `.callout` family (`--note` info-blue / `--tip` brand-green / `--warning` warm-amber / `--key` neutral).
- **`NewBlogPost.jsx` + `KeyTakeaways.jsx`** — wrapped in `.theme-modern` + `preloadModernFonts()`; replaced Tailwind `.prose` with `.prose-modern`; **de-gradient 100%**; border-first header/TOC/author/related; in-post callouts use the primitives; orange stays affiliate-only.

## SEO preserved byte-for-byte
`useSEO`/`generatePageSEO` + all JSON-LD (schema lives in the untouched SEO hook) + meta/canonical/dates unchanged; body `h1/h2/h3` renderers keep tag + id-anchor + text; in-article links + hrefs unchanged; affiliate `<a>` keep `rel="nofollow sponsored …"` + `data-*` + **no `onClick`**.

## Two minor, review-endorsed improvements
- Demoted the **post subtitle** (`h2`→`p.lead`) and **TOC label** (`h3`→`p`) so nav/title chrome no longer pollutes the article heading outline (body headings untouched — cleaner for SEO).
- Hid a dev **"Dynamically Loaded" diagnostics card** in production.

## Verified
- `restyle-blog` **17/17** + `layout-invariants` (blog-post route, both projects) **8/8**. I also **added the blog-post route to the invariants gate** so the template is permanently protected.
- Build prerenders **all 197 posts (0 errors)** + 7 pages.
- Ground-truth screenshots (desktop + mobile) — Fraunces headings, comfortable Inter reading measure, border-first callouts. **0 post-JSON edits** (moratorium-safe).

Closes #384. **Closes #381** (callout + form primitives complete). **Completes the rest-of-site restyle epic #380.**