### PR TITLE
fix(nav): Topics mega-menu hover-gap (dropdown vanishes before you can click)

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -45,6 +45,7 @@ function Layout({ children }) {
   const [mounted, setMounted] = useState(false)
   const topicsRef = useRef(null)
   const dropdownRef = useRef(null)
+  const closeTimerRef = useRef(null)
   const { navigate, isActive, getNavItems } = useRouter()
   const { headerRef, headerHeight } = useHeaderHeight()
 
@@ -73,6 +74,20 @@ function Layout({ children }) {
       document.removeEventListener('mousedown', onClick)
     }
   }, [isTopicsOpen])
+
+  // Open/close the Topics dropdown with a short close-DELAY so the cursor can
+  // cross the small gap between the trigger and the portaled dropdown (top:
+  // headerHeight+8, in document.body) without the frame vanishing. Entering
+  // either the trigger or the dropdown cancels a pending close. (hover-gap fix)
+  const openTopics = useCallback(() => {
+    if (closeTimerRef.current) { clearTimeout(closeTimerRef.current); closeTimerRef.current = null }
+    setIsTopicsOpen(true)
+  }, [])
+  const scheduleCloseTopics = useCallback(() => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = setTimeout(() => setIsTopicsOpen(false), 200)
+  }, [])
+  useEffect(() => () => { if (closeTimerRef.current) clearTimeout(closeTimerRef.current) }, [])
 
   // A/B Test #255: Nav CTA copy re-test (previously #134)
   const navCtaVariant = useFeatureFlag('nav-cta-copy-v1', 'control')
@@ -162,8 +177,8 @@ function Layout({ children }) {
                       key="topics-dropdown"
                       ref={topicsRef}
                       className="relative"
-                      onMouseEnter={() => setIsTopicsOpen(true)}
-                      onMouseLeave={() => setIsTopicsOpen(false)}
+                      onMouseEnter={openTopics}
+                      onMouseLeave={scheduleCloseTopics}
                     >
                       <button
                         type="button"
@@ -409,8 +424,8 @@ function Layout({ children }) {
           id="topics-mega-menu"
           role="region"
           aria-label="Topics"
-          onMouseEnter={() => setIsTopicsOpen(true)}
-          onMouseLeave={() => setIsTopicsOpen(false)}
+          onMouseEnter={openTopics}
+          onMouseLeave={scheduleCloseTopics}
           style={{
             top: headerHeight + 8,
             backgroundColor: 'var(--color-surface)',

--- a/tests/topics-menu-hover.spec.js
+++ b/tests/topics-menu-hover.spec.js
@@ -1,0 +1,66 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression for the Topics mega-menu hover-gap bug (reported 2026-07-18):
+ * "as soon as your mouse tries to mouse over the expanded topics, the frame
+ * disappears." The trigger closed on mouseleave with NO delay, and the dropdown
+ * is portaled to <body> with an 8px gap below the header — so moving the cursor
+ * from the trigger toward the dropdown crossed dead space, fired the trigger's
+ * mouseleave, and unmounted the portal before the cursor ever reached it.
+ *
+ * RED on the immediate-close version; GREEN once a close-delay bridges the gap.
+ */
+
+test.describe('Topics mega-menu — hover-gap', () => {
+  test('survives the mouse crossing the trigger→dropdown gap and is clickable', async ({ page }) => {
+    const isMobile = (page.viewportSize()?.width ?? 1280) < 1024;
+    test.skip(isMobile, 'mega-menu is a desktop hover UI; mobile uses the collapsible Topics section');
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const trigger = page.getByRole('button', { name: 'Topics' });
+    await expect(trigger).toBeVisible();
+    await trigger.hover();
+
+    const menu = page.locator('#topics-mega-menu');
+    await expect(menu).toBeVisible();
+
+    const tbox = await trigger.boundingBox();
+    const mbox = await menu.boundingBox();
+    if (!tbox || !mbox) throw new Error('missing boxes');
+
+    // Trace the real cursor path: on the trigger → through the GAP → onto the menu.
+    await page.mouse.move(tbox.x + tbox.width / 2, tbox.y + tbox.height / 2, { steps: 3 });
+    await page.mouse.move(mbox.x + mbox.width / 2, tbox.y + tbox.height + 4, { steps: 4 }); // in the gap
+    await page.mouse.move(mbox.x + mbox.width / 2, mbox.y + 24, { steps: 6 });               // onto the menu
+
+    // The frame must NOT have vanished mid-move.
+    await expect(menu, 'menu must stay open while moving onto it').toBeVisible();
+
+    // And a topic must actually be clickable → navigates.
+    const topic = menu.getByRole('link').first();
+    await expect(topic).toBeVisible();
+    const href = await topic.getAttribute('href');
+    await topic.click();
+    await expect(page).toHaveURL(new RegExp(href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/^\//, '/') + '$'));
+  });
+
+  test('stays open when the cursor rests on the dropdown, closes shortly after leaving', async ({ page }) => {
+    const isMobile = (page.viewportSize()?.width ?? 1280) < 1024;
+    test.skip(isMobile, 'desktop hover UI');
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Topics' }).hover();
+    const menu = page.locator('#topics-mega-menu');
+    await expect(menu).toBeVisible();
+    await menu.hover();
+    await page.waitForTimeout(400);
+    await expect(menu, 'stays open while hovered').toBeVisible();
+    // Move far away → it should close (not stick open forever).
+    await page.mouse.move(20, 400, { steps: 4 });
+    await expect(menu).toBeHidden({ timeout: 2000 });
+  });
+});


### PR DESCRIPTION
**Reported:** *"as soon as your mouse tries to mouse over the expanded topics, the frame disappears"* — the Topics dropdown was unusable.

## Cause
The dropdown is portaled to `<body>` at `top: headerHeight + 8` (an 8px gap below the header), and the trigger closed on `mouseleave` with **no delay**. Moving the cursor from the trigger toward the dropdown crossed the gap → trigger's `mouseleave` fired → `setIsTopicsOpen(false)` → the portal **unmounted before the cursor reached it**.

## Fix
A shared **200ms close-delay**: leaving the trigger *or* dropdown schedules a close; entering either cancels it (`openTopics` / `scheduleCloseTopics` on both, timer cleared on unmount). The cursor can bridge the gap; it still closes shortly after you truly leave.

## TDD
`tests/topics-menu-hover.spec.js` traces the real cursor path (trigger → gap → dropdown) and asserts the menu stays visible + a topic is clickable and navigates — **RED** on the old immediate-close, **GREEN** now. The existing mega-menu overlap specs (11) still pass; build green.